### PR TITLE
TGV-Regularizer and SolverState

### DIFF
--- a/src/main/java/net/imagej/ops/fopd/Ascent.java
+++ b/src/main/java/net/imagej/ops/fopd/Ascent.java
@@ -2,8 +2,8 @@ package net.imagej.ops.fopd;
 
 import net.imagej.ops.fopd.costfunction.CostFunction;
 import net.imagej.ops.fopd.regularizer.Regularizer;
-import net.imagej.ops.special.hybrid.UnaryHybridCF;
-import net.imglib2.RandomAccessibleInterval;
+import net.imagej.ops.fopd.solver.SolverState;
+import net.imagej.ops.special.function.UnaryFunctionOp;
 import net.imglib2.type.numeric.RealType;
 
 /**
@@ -15,6 +15,6 @@ import net.imglib2.type.numeric.RealType;
  * @param <T>
  */
 public interface Ascent<T extends RealType<T>>
-		extends UnaryHybridCF<DualVariables<T>, RandomAccessibleInterval<T>> {
+		extends UnaryFunctionOp<SolverState<T>, SolverState<T>> {
 	// NB: Marker Interface
 }

--- a/src/main/java/net/imagej/ops/fopd/Descent.java
+++ b/src/main/java/net/imagej/ops/fopd/Descent.java
@@ -2,8 +2,8 @@ package net.imagej.ops.fopd;
 
 import net.imagej.ops.fopd.costfunction.CostFunction;
 import net.imagej.ops.fopd.regularizer.Regularizer;
-import net.imagej.ops.special.hybrid.UnaryHybridCF;
-import net.imglib2.RandomAccessibleInterval;
+import net.imagej.ops.fopd.solver.SolverState;
+import net.imagej.ops.special.function.UnaryFunctionOp;
 import net.imglib2.type.numeric.RealType;
 
 /**
@@ -15,6 +15,6 @@ import net.imglib2.type.numeric.RealType;
  * @param <T>
  */
 public interface Descent<T extends RealType<T>>
-		extends UnaryHybridCF<DualVariables<T>, RandomAccessibleInterval<T>> {
+		extends UnaryFunctionOp<SolverState<T>, SolverState<T>> {
 	// NB: Marker Interface
 }

--- a/src/main/java/net/imagej/ops/fopd/DualVariables.java
+++ b/src/main/java/net/imagej/ops/fopd/DualVariables.java
@@ -27,10 +27,9 @@ public class DualVariables<T extends RealType<T>> {
 	public RandomAccessibleInterval<T> getDualVariable(final int i) {
 		if (i <= numVariables) {
 			return dualVariables[i];
-		} else {
-			throw new ArrayIndexOutOfBoundsException(
-					"Only " + numVariables + " dual variables are available. Dual variable " + i + " was requested.");
 		}
+		throw new ArrayIndexOutOfBoundsException(
+				"Only " + numVariables + " dual variables are available. Dual variable " + i + " was requested.");
 	}
 
 	public T getType() {
@@ -41,7 +40,7 @@ public class DualVariables<T extends RealType<T>> {
 		return this.numVariables;
 	}
 
-	public RandomAccessibleInterval<T>[] getAllDUalVariables() {
+	public RandomAccessibleInterval<T>[] getAllDualVariables() {
 		return this.dualVariables;
 	}
 }

--- a/src/main/java/net/imagej/ops/fopd/Examples.java
+++ b/src/main/java/net/imagej/ops/fopd/Examples.java
@@ -29,9 +29,11 @@ public class Examples {
 		ImageJFunctions.show(ex.getNoisyImg());
 		ImageJFunctions.show(ex.denoisingL1TV2D(ex.getNoisyImg(), numIts));
 		ImageJFunctions.show(ex.denoisingL1TVHuber2D(ex.getNoisyImg(), numIts));
+		ImageJFunctions.show(ex.denoisingL1TGV2D(ex.getNoisyImg(), numIts));
 		ImageJFunctions.show(ex.getConvolvedImg());
 		ImageJFunctions.show(ex.deconvolutionL1TV2D(ex.getConvolvedImg(), ex.getKernel(), numIts));
 		ImageJFunctions.show(ex.deconvolutionL1TVHuber2D(ex.getConvolvedImg(), ex.getKernel(), numIts));
+		ImageJFunctions.show(ex.deconvolutionL1TGV2D(ex.getConvolvedImg(), ex.getKernel(), numIts));
 	}
 
 	public Examples() {
@@ -76,6 +78,18 @@ public class Examples {
 	}
 
 	@SuppressWarnings("unchecked")
+	private Img<FloatType> denoisingL1TGV2D(final Img<FloatType> img, final int numIts) {
+
+		long t = System.currentTimeMillis();
+		final Img<FloatType> result = (Img<FloatType>) ops.run(TGVL1Denoising.class, img, 1.0, 2.0, numIts);
+		t = System.currentTimeMillis() - t;
+		System.out.println(
+				"TGVL1-Denoising [" + img.dimension(0) + ", " + img.dimension(1) + "]: " + t / 1000.0 + "sec");
+		System.out.println("Time/Iteration: " + (double) t / numIts + "millisec");
+		return result;
+	}
+
+	@SuppressWarnings("unchecked")
 	private Img<FloatType> deconvolutionL1TV2D(final Img<FloatType> img, final Img<FloatType> kernel,
 			final int numIts) {
 
@@ -87,16 +101,30 @@ public class Examples {
 		System.out.println("Time/Iteration: " + (double) t / numIts + "millisec");
 		return result;
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	private Img<FloatType> deconvolutionL1TVHuber2D(final Img<FloatType> img, final Img<FloatType> kernel,
 			final int numIts) {
 
 		long t = System.currentTimeMillis();
-		final Img<FloatType> result = (Img<FloatType>) ops.run(TVHuberL1Deconvolution.class, img, kernel, 0.1, 0.05, numIts);
+		final Img<FloatType> result = (Img<FloatType>) ops.run(TVHuberL1Deconvolution.class, img, kernel, 0.1, 0.05,
+				numIts);
 		t = System.currentTimeMillis() - t;
 		System.out.println(
 				"TVHuberL1-Deconvolution [" + img.dimension(0) + ", " + img.dimension(1) + "]: " + t / 1000.0 + "sec");
+		System.out.println("Time/Iteration: " + (double) t / numIts + "millisec");
+		return result;
+	}
+
+	@SuppressWarnings("unchecked")
+	private Img<FloatType> deconvolutionL1TGV2D(final Img<FloatType> img, final Img<FloatType> kernel,
+			final int numIts) {
+
+		long t = System.currentTimeMillis();
+		final Img<FloatType> result = (Img<FloatType>) ops.run(TGVL1Deconvolution.class, img, kernel, 0.1, 0.2, numIts);
+		t = System.currentTimeMillis() - t;
+		System.out.println(
+				"TGVL1-Deconvolution [" + img.dimension(0) + ", " + img.dimension(1) + "]: " + t / 1000.0 + "sec");
 		System.out.println("Time/Iteration: " + (double) t / numIts + "millisec");
 		return result;
 	}

--- a/src/main/java/net/imagej/ops/fopd/TGVL1Deconvolution.java
+++ b/src/main/java/net/imagej/ops/fopd/TGVL1Deconvolution.java
@@ -1,0 +1,62 @@
+package net.imagej.ops.fopd;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.fopd.costfunction.CostFunction;
+import net.imagej.ops.fopd.costfunction.deconvolution.L1Deconvolution2D;
+import net.imagej.ops.fopd.regularizer.Regularizer;
+import net.imagej.ops.fopd.regularizer.tgv.TGV2D;
+import net.imagej.ops.fopd.solver.DefaultSolver;
+import net.imagej.ops.fopd.solver.TGVL1DenoisingSolverState;
+import net.imagej.ops.special.function.AbstractBinaryFunctionOp;
+import net.imagej.ops.special.hybrid.UnaryHybridCF;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.view.Views;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * A 2D deconvolution algorithm which uses TGV as {@link Regularizer} and takes
+ * the L1-Norm as {@link CostFunction}.
+ * 
+ * Energy: E(u) = lambda * TGV(u) + |u - f|_1, where u is the deconvolved
+ * solution, lambda is the smoothness weight, k is the known kernel, * is the
+ * convolution operator and f is the observed image.
+ * 
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ */
+@Plugin(type = UnaryHybridCF.class)
+public class TGVL1Deconvolution<T extends RealType<T>> extends
+		AbstractBinaryFunctionOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> {
+
+	@Parameter
+	private OpService ops;
+
+	@Parameter
+	private double alpha;
+
+	@Parameter
+	private double beta;
+
+	@Parameter
+	private int numIt;
+
+	@SuppressWarnings({ "unchecked" })
+	public RandomAccessibleInterval<T> calculate(RandomAccessibleInterval<T> image,
+			RandomAccessibleInterval<T> kernel) {
+
+		final TGV2D<T> tgv = new TGV2D<T>(ops, alpha, beta, 0.2);
+		RandomAccessibleInterval<T> flippedKernel = ops.copy().rai(kernel);
+		final L1Deconvolution2D<T> cf = new L1Deconvolution2D<T>(ops, image, kernel,
+				Views.invertAxis(Views.invertAxis(flippedKernel, 0), 1), 0.2);
+
+		final TGVL1DenoisingSolverState<T> state = new TGVL1DenoisingSolverState<T>(ops, image);
+
+		final DefaultSolver<T> solver = ops.op(DefaultSolver.class, state, tgv, cf, numIt);
+		solver.calculate(state);
+
+		return state.getResultImage(0);
+	}
+}

--- a/src/main/java/net/imagej/ops/fopd/TGVL1Denoising.java
+++ b/src/main/java/net/imagej/ops/fopd/TGVL1Denoising.java
@@ -1,0 +1,55 @@
+package net.imagej.ops.fopd;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.fopd.costfunction.CostFunction;
+import net.imagej.ops.fopd.costfunction.denoising.L1Denoising2D;
+import net.imagej.ops.fopd.regularizer.Regularizer;
+import net.imagej.ops.fopd.regularizer.tgv.TGV2D;
+import net.imagej.ops.fopd.solver.DefaultSolver;
+import net.imagej.ops.fopd.solver.TGVL1DenoisingSolverState;
+import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
+import net.imagej.ops.special.hybrid.UnaryHybridCF;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.RealType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * A 2D denoising algorithm which uses TV as {@link Regularizer} and takes the
+ * L1-Norm as {@link CostFunction}.
+ * 
+ * Energy: E(u) = lambda * TV(u) + |u - f|_1, where u is the denoised solution,
+ * lambda is the smoothness weight and f is the observed image.
+ * 
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ */
+@Plugin(type = UnaryHybridCF.class)
+public class TGVL1Denoising<T extends RealType<T>>
+		extends AbstractUnaryFunctionOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> {
+
+	@Parameter
+	private OpService ops;
+
+	@Parameter
+	private double alpha;
+
+	@Parameter
+	private double beta;
+
+	@Parameter
+	private int numIt;
+
+	@SuppressWarnings({ "unchecked" })
+	public RandomAccessibleInterval<T> calculate(RandomAccessibleInterval<T> input) {
+
+		final TGV2D<T> tgv = new TGV2D<T>(ops, alpha, beta, 0.25);
+		final L1Denoising2D<T> cf = new L1Denoising2D<T>(ops, input, 0.25);
+
+		final TGVL1DenoisingSolverState<T> state = new TGVL1DenoisingSolverState<T>(ops, input);
+
+		final DefaultSolver<T> solver = ops.op(DefaultSolver.class, state, tgv, cf, numIt);
+		return solver.calculate(state);
+	}
+}

--- a/src/main/java/net/imagej/ops/fopd/TVHuberL1Deconvolution.java
+++ b/src/main/java/net/imagej/ops/fopd/TVHuberL1Deconvolution.java
@@ -3,13 +3,11 @@ package net.imagej.ops.fopd;
 import net.imagej.ops.OpService;
 import net.imagej.ops.fopd.costfunction.CostFunction;
 import net.imagej.ops.fopd.costfunction.deconvolution.L1Deconvolution2D;
-import net.imagej.ops.fopd.costfunction.denoising.L1Denoising2D;
 import net.imagej.ops.fopd.regularizer.Regularizer;
-import net.imagej.ops.fopd.regularizer.TVHuber2D;
-import net.imagej.ops.fopd.regularizer.TotalVariation2D;
+import net.imagej.ops.fopd.regularizer.tvhuber.TVHuber2D;
 import net.imagej.ops.fopd.solver.DefaultSolver;
 import net.imagej.ops.fopd.solver.TVL1Deconvolution2DSolverState;
-import net.imagej.ops.special.hybrid.AbstractBinaryHybridCF;
+import net.imagej.ops.special.function.AbstractBinaryFunctionOp;
 import net.imagej.ops.special.hybrid.UnaryHybridCF;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
@@ -19,49 +17,46 @@ import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
- * A 2D denoising algorithm which uses TV as {@link Regularizer} and takes the
- * L1-Norm as {@link CostFunction}.
+ * A 2D deconvolved algorithm which uses TV-Huber as {@link Regularizer} and
+ * takes the L1-Norm as {@link CostFunction}.
  * 
- * Energy: E(u) = lambda * TV(u) + |u - f|_1, where u is the denoised solution,
- * lambda is the smoothness weight and f is the observed image.
+ * Energy: E(u) = lambda * TV_Huber(u) + |u*k - f|_1, where u is the deconvolved
+ * solution, lambda is the smoothness weight, k is the known kernel, * is the
+ * convolution operator and f is the observed image.
  * 
  * @author Tim-Oliver Buchholz, University of Konstanz
  *
  */
 @Plugin(type = UnaryHybridCF.class)
 public class TVHuberL1Deconvolution<T extends RealType<T>> extends
-		AbstractBinaryHybridCF<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> {
+		AbstractBinaryFunctionOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> {
 
 	@Parameter
 	private OpService ops;
 
 	@Parameter
 	private double lambda;
-	
+
 	@Parameter
 	private double alpha;
 
 	@Parameter
 	private int numIt;
 
-	@SuppressWarnings("unchecked")
-	public RandomAccessibleInterval<T> createOutput(RandomAccessibleInterval<T> image,
-			RandomAccessibleInterval<T> kernel) {
-		return (RandomAccessibleInterval<T>) ops.create().img(image);
-	}
-
 	@SuppressWarnings({ "unchecked" })
-	public void compute(RandomAccessibleInterval<T> image, RandomAccessibleInterval<T> kernel,
-			RandomAccessibleInterval<T> uq) {
+	public RandomAccessibleInterval<T> calculate(RandomAccessibleInterval<T> image,
+			RandomAccessibleInterval<T> kernel) {
 
 		final TVHuber2D<T> tv = new TVHuber2D<T>(ops, lambda, alpha, 0.2);
 		RandomAccessibleInterval<T> flippedKernel = ops.copy().rai(kernel);
-		final L1Deconvolution2D<T> cf = new L1Deconvolution2D<T>(ops, image, kernel, Views.invertAxis(Views.invertAxis(flippedKernel, 0), 1), 0.2);
+		final L1Deconvolution2D<T> cf = new L1Deconvolution2D<T>(ops, image, kernel,
+				Views.invertAxis(Views.invertAxis(flippedKernel, 0), 1), 0.2);
 
-		final TVL1Deconvolution2DSolverState<T> state = new TVL1Deconvolution2DSolverState<T>(ops, numIt, lambda, image,
-				kernel);
+		final TVL1Deconvolution2DSolverState<T> state = new TVL1Deconvolution2DSolverState<T>(ops, image);
 
-		final DefaultSolver<T> solver = ops.op(DefaultSolver.class, uq, state, tv, cf);
-		solver.compute(state, uq);
+		final DefaultSolver<T> solver = ops.op(DefaultSolver.class, state, tv, cf, numIt);
+		solver.calculate(state);
+
+		return state.getResultImage(0);
 	}
 }

--- a/src/main/java/net/imagej/ops/fopd/TVHuberL1Denoising.java
+++ b/src/main/java/net/imagej/ops/fopd/TVHuberL1Denoising.java
@@ -4,10 +4,10 @@ import net.imagej.ops.OpService;
 import net.imagej.ops.fopd.costfunction.CostFunction;
 import net.imagej.ops.fopd.costfunction.denoising.L1Denoising2D;
 import net.imagej.ops.fopd.regularizer.Regularizer;
-import net.imagej.ops.fopd.regularizer.TVHuber2D;
+import net.imagej.ops.fopd.regularizer.tvhuber.TVHuber2D;
 import net.imagej.ops.fopd.solver.DefaultSolver;
 import net.imagej.ops.fopd.solver.TVHuberL1DenoisingSolverState;
-import net.imagej.ops.special.hybrid.AbstractUnaryHybridCF;
+import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
 import net.imagej.ops.special.hybrid.UnaryHybridCF;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
@@ -27,7 +27,7 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = UnaryHybridCF.class)
 public class TVHuberL1Denoising<T extends RealType<T>>
-		extends AbstractUnaryHybridCF<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> {
+		extends AbstractUnaryFunctionOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> {
 
 	@Parameter
 	private OpService ops;
@@ -41,21 +41,16 @@ public class TVHuberL1Denoising<T extends RealType<T>>
 	@Parameter
 	private int numIt;
 
-	@SuppressWarnings("unchecked")
-	public RandomAccessibleInterval<T> createOutput(RandomAccessibleInterval<T> input) {
-		return (RandomAccessibleInterval<T>) ops.create().img(input);
-	}
-
 	@SuppressWarnings({ "unchecked" })
-	public void compute(RandomAccessibleInterval<T> input, RandomAccessibleInterval<T> uq) {
+	public RandomAccessibleInterval<T> calculate(RandomAccessibleInterval<T> input) {
 
-		final TVHuberL1DenoisingSolverState<T> state = new TVHuberL1DenoisingSolverState<T>(ops, numIt, lambda, alpha,
+		final TVHuberL1DenoisingSolverState<T> state = new TVHuberL1DenoisingSolverState<T>(ops,
 				input);
 
-		final TVHuber2D<T> tv = new TVHuber2D<T>(ops, state.getLambda(), state.getAlpha(), 0.25);
+		final TVHuber2D<T> tv = new TVHuber2D<T>(ops, lambda, alpha, 0.25);
 		final L1Denoising2D<T> cf = new L1Denoising2D<T>(ops, input, 0.25);
 
-		final DefaultSolver<T> solver = ops.op(DefaultSolver.class, uq, state, tv, cf);
-		solver.compute(state, uq);
+		final DefaultSolver<T> solver = ops.op(DefaultSolver.class, state, tv, cf, numIt);
+		return solver.calculate(state);
 	}
 }

--- a/src/main/java/net/imagej/ops/fopd/TVL1Deconvolution.java
+++ b/src/main/java/net/imagej/ops/fopd/TVL1Deconvolution.java
@@ -3,12 +3,11 @@ package net.imagej.ops.fopd;
 import net.imagej.ops.OpService;
 import net.imagej.ops.fopd.costfunction.CostFunction;
 import net.imagej.ops.fopd.costfunction.deconvolution.L1Deconvolution2D;
-import net.imagej.ops.fopd.costfunction.denoising.L1Denoising2D;
 import net.imagej.ops.fopd.regularizer.Regularizer;
-import net.imagej.ops.fopd.regularizer.TotalVariation2D;
+import net.imagej.ops.fopd.regularizer.tv.TotalVariation2D;
 import net.imagej.ops.fopd.solver.DefaultSolver;
 import net.imagej.ops.fopd.solver.TVL1Deconvolution2DSolverState;
-import net.imagej.ops.special.hybrid.AbstractBinaryHybridCF;
+import net.imagej.ops.special.function.AbstractBinaryFunctionOp;
 import net.imagej.ops.special.hybrid.UnaryHybridCF;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
@@ -18,18 +17,19 @@ import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
- * A 2D denoising algorithm which uses TV as {@link Regularizer} and takes the
- * L1-Norm as {@link CostFunction}.
+ * A 2D deconvolution algorithm which uses TV as {@link Regularizer} and takes
+ * the L1-Norm as {@link CostFunction}.
  * 
- * Energy: E(u) = lambda * TV(u) + |u - f|_1, where u is the denoised solution,
- * lambda is the smoothness weight and f is the observed image.
+ * Energy: E(u) = lambda * TV(u) + |u - f|_1, where u is the deconvolved
+ * solution, lambda is the smoothness weight, k is the known kernel, * is the
+ * convolution operator and f is the observed image.
  * 
  * @author Tim-Oliver Buchholz, University of Konstanz
  *
  */
 @Plugin(type = UnaryHybridCF.class)
 public class TVL1Deconvolution<T extends RealType<T>> extends
-		AbstractBinaryHybridCF<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> {
+		AbstractBinaryFunctionOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> {
 
 	@Parameter
 	private OpService ops;
@@ -40,24 +40,20 @@ public class TVL1Deconvolution<T extends RealType<T>> extends
 	@Parameter
 	private int numIt;
 
-	@SuppressWarnings("unchecked")
-	public RandomAccessibleInterval<T> createOutput(RandomAccessibleInterval<T> image,
-			RandomAccessibleInterval<T> kernel) {
-		return (RandomAccessibleInterval<T>) ops.create().img(image);
-	}
-
 	@SuppressWarnings({ "unchecked" })
-	public void compute(RandomAccessibleInterval<T> image, RandomAccessibleInterval<T> kernel,
-			RandomAccessibleInterval<T> uq) {
+	public RandomAccessibleInterval<T> calculate(RandomAccessibleInterval<T> image,
+			RandomAccessibleInterval<T> kernel) {
 
 		final TotalVariation2D<T> tv = new TotalVariation2D<T>(ops, lambda, 0.2);
 		RandomAccessibleInterval<T> flippedKernel = ops.copy().rai(kernel);
-		final L1Deconvolution2D<T> cf = new L1Deconvolution2D<T>(ops, image, kernel, Views.invertAxis(Views.invertAxis(flippedKernel, 0), 1), 0.2);
+		final L1Deconvolution2D<T> cf = new L1Deconvolution2D<T>(ops, image, kernel,
+				Views.invertAxis(Views.invertAxis(flippedKernel, 0), 1), 0.2);
 
-		final TVL1Deconvolution2DSolverState<T> state = new TVL1Deconvolution2DSolverState<T>(ops, numIt, lambda, image,
-				kernel);
+		final TVL1Deconvolution2DSolverState<T> state = new TVL1Deconvolution2DSolverState<T>(ops, image);
 
-		final DefaultSolver<T> solver = ops.op(DefaultSolver.class, uq, state, tv, cf);
-		solver.compute(state, uq);
+		final DefaultSolver<T> solver = ops.op(DefaultSolver.class, state, tv, cf, numIt);
+		solver.calculate(state);
+
+		return state.getResultImage(0);
 	}
 }

--- a/src/main/java/net/imagej/ops/fopd/costfunction/deconvolution/L1Deconvolution2D.java
+++ b/src/main/java/net/imagej/ops/fopd/costfunction/deconvolution/L1Deconvolution2D.java
@@ -1,11 +1,10 @@
 package net.imagej.ops.fopd.costfunction.deconvolution;
 
 import net.imagej.ops.OpService;
-import net.imagej.ops.fopd.DualVariables;
 import net.imagej.ops.fopd.costfunction.AbstractCostFunction;
+import net.imagej.ops.fopd.solver.SolverState;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
-import net.imglib2.view.Views;
 
 /**
  * Deconvolution with L1-Norm of one 2D image.
@@ -23,9 +22,9 @@ public class L1Deconvolution2D<T extends RealType<T>> extends AbstractCostFuncti
 	public L1Deconvolution2D(final OpService ops, final RandomAccessibleInterval<T> image,
 			final RandomAccessibleInterval<T> kernel, final RandomAccessibleInterval<T> flippedKernel,
 			final double descentStepSize) {
-		this.ascent = ops.op(L1Deconvolution2DAscent.class, RandomAccessibleInterval.class, DualVariables.class, image,
+		this.ascent = ops.op(L1Deconvolution2DAscent.class, SolverState.class, image,
 				kernel);
-		this.descent = ops.op(L1Deconvolution2DDescent.class, RandomAccessibleInterval.class, DualVariables.class,
+		this.descent = ops.op(L1Deconvolution2DDescent.class, SolverState.class,
 				flippedKernel, descentStepSize);
 	}
 }

--- a/src/main/java/net/imagej/ops/fopd/costfunction/denoising/L1Denoising2D.java
+++ b/src/main/java/net/imagej/ops/fopd/costfunction/denoising/L1Denoising2D.java
@@ -1,8 +1,8 @@
 package net.imagej.ops.fopd.costfunction.denoising;
 
 import net.imagej.ops.OpService;
-import net.imagej.ops.fopd.DualVariables;
 import net.imagej.ops.fopd.costfunction.AbstractCostFunction;
+import net.imagej.ops.fopd.solver.SolverState;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
@@ -20,8 +20,8 @@ public class L1Denoising2D<T extends RealType<T>> extends AbstractCostFunction<T
 
 	@SuppressWarnings("unchecked")
 	public L1Denoising2D(final OpService ops, final RandomAccessibleInterval<T> image, final double descentStepSize) {
-		this.ascent = ops.op(L1DenoisingAscent.class, RandomAccessibleInterval.class, DualVariables.class, image);
-		this.descent = ops.op(L1DenoisingDescent.class, RandomAccessibleInterval.class, DualVariables.class,
+		this.ascent = ops.op(L1DenoisingAscent.class, SolverState.class, image);
+		this.descent = ops.op(L1DenoisingDescent.class, SolverState.class,
 				descentStepSize);
 	}
 }

--- a/src/main/java/net/imagej/ops/fopd/costfunction/denoising/L1DenoisingAscent.java
+++ b/src/main/java/net/imagej/ops/fopd/costfunction/denoising/L1DenoisingAscent.java
@@ -7,12 +7,13 @@ import net.imagej.ops.fopd.Ascent;
 import net.imagej.ops.fopd.DualVariables;
 import net.imagej.ops.fopd.helper.DefaultL1Projector;
 import net.imagej.ops.fopd.helper.DefaultL2Norm;
+import net.imagej.ops.fopd.solver.SolverState;
 import net.imagej.ops.map.MapBinaryComputers.RAIAndRAIToIIParallel;
 import net.imagej.ops.map.MapBinaryInplace1s.IIAndIIParallel;
 import net.imagej.ops.special.computer.BinaryComputerOp;
 import net.imagej.ops.special.computer.Computers;
 import net.imagej.ops.special.computer.UnaryComputerOp;
-import net.imagej.ops.special.hybrid.AbstractUnaryHybridCF;
+import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
 import net.imagej.ops.special.inplace.BinaryInplace1Op;
 import net.imagej.ops.special.inplace.Inplaces;
 import net.imglib2.IterableInterval;
@@ -31,7 +32,7 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ascent.class)
 public class L1DenoisingAscent<T extends RealType<T>>
-		extends AbstractUnaryHybridCF<DualVariables<T>, RandomAccessibleInterval<T>> implements Ascent<T> {
+		extends AbstractUnaryFunctionOp<SolverState<T>, SolverState<T>> implements Ascent<T> {
 
 	@Parameter
 	private OpService ops;
@@ -47,28 +48,27 @@ public class L1DenoisingAscent<T extends RealType<T>>
 	private RandomAccessibleInterval<T> norm;
 
 	@SuppressWarnings("rawtypes")
-	private UnaryComputerOp<DualVariables, RandomAccessibleInterval> normComputer;
+	private UnaryComputerOp<RandomAccessibleInterval[], RandomAccessibleInterval> normComputer;
 
 	private IIAndIIParallel<T, T> inplaceMapper;
 
 	@SuppressWarnings("unchecked")
-	public RandomAccessibleInterval<T> createOutput(DualVariables<T> input) {
-		return (RandomAccessibleInterval<T>) ops.create().img(input.getDualVariable(0));
-	}
-
-	@SuppressWarnings("unchecked")
-	public void compute(DualVariables<T> input, RandomAccessibleInterval<T> output) {
+	public SolverState<T> calculate(SolverState<T> input) {
+		final DualVariables<T> dualVariables = input.getCostFunctionDV();
+		
 		if (mapperSubtract == null || mapperAdd == null || diff == null || norm == null || normComputer == null
 				|| inplaceMapper == null) {
-			init(input);
+			init(dualVariables);
 		}
 
-		mapperSubtract.compute(output, f, (IterableInterval<T>) diff);
+		mapperSubtract.compute(input.getResultImage(0), f, (IterableInterval<T>) diff);
 
-		mapperAdd.compute(input.getDualVariable(0), diff, (IterableInterval<T>) input.getDualVariable(0));
+		mapperAdd.compute(dualVariables.getDualVariable(0), diff, (IterableInterval<T>) dualVariables.getDualVariable(0));
 
-		normComputer.compute(input, norm);
-		inplaceMapper.mutate1((IterableInterval<T>) input.getDualVariable(0), (IterableInterval<T>) norm);
+		normComputer.compute(dualVariables.getAllDualVariables(), norm);
+		inplaceMapper.mutate1((IterableInterval<T>) dualVariables.getDualVariable(0), (IterableInterval<T>) norm);
+		
+		return input;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -87,7 +87,7 @@ public class L1DenoisingAscent<T extends RealType<T>>
 		diff = (RandomAccessibleInterval<T>) ops.create().img(input.getDualVariable(0));
 
 		norm = (RandomAccessibleInterval<T>) ops.create().img(input.getDualVariable(0));
-		normComputer = Computers.unary(ops, DefaultL2Norm.class, RandomAccessibleInterval.class, DualVariables.class);
+		normComputer = Computers.unary(ops, DefaultL2Norm.class, RandomAccessibleInterval.class, RandomAccessibleInterval[].class);
 		final BinaryInplace1Op<? super T, T, T> projector = Inplaces.binary1(ops, DefaultL1Projector.class,
 				input.getType(), input.getType(), 1);
 		inplaceMapper = (IIAndIIParallel<T, T>) ops.op(Map.class, IterableInterval.class, IterableInterval.class,

--- a/src/main/java/net/imagej/ops/fopd/helper/Default01Clipper.java
+++ b/src/main/java/net/imagej/ops/fopd/helper/Default01Clipper.java
@@ -1,10 +1,10 @@
 package net.imagej.ops.fopd.helper;
 
-import org.scijava.plugin.Plugin;
-
 import net.imagej.ops.special.inplace.AbstractUnaryInplaceOp;
 import net.imagej.ops.special.inplace.UnaryInplaceOp;
 import net.imglib2.type.numeric.RealType;
+
+import org.scijava.plugin.Plugin;
 
 /**
  * Implementation of {@link MinMaxClipper} which clips to 0 and 1.

--- a/src/main/java/net/imagej/ops/fopd/helper/DefaultBackwardDifference.java
+++ b/src/main/java/net/imagej/ops/fopd/helper/DefaultBackwardDifference.java
@@ -1,9 +1,5 @@
 package net.imagej.ops.fopd.helper;
 
-import org.scijava.Priority;
-import org.scijava.plugin.Parameter;
-import org.scijava.plugin.Plugin;
-
 import net.imagej.ops.OpService;
 import net.imagej.ops.special.hybrid.AbstractUnaryHybridCF;
 import net.imglib2.FinalInterval;
@@ -14,6 +10,10 @@ import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.util.Intervals;
 import net.imglib2.view.Views;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
 
 /**
  * Implementation of {@link BackwardDifference} for the given dimension d.
@@ -28,7 +28,7 @@ public class DefaultBackwardDifference<T extends RealType<T>>
 		implements BackwardDifference<T> {
 
 	@Parameter
-	private int d;
+	private int dimension;
 	
 	@Parameter
 	private OutOfBoundsFactory<T, RandomAccessibleInterval<T>> fac;
@@ -54,7 +54,7 @@ public class DefaultBackwardDifference<T extends RealType<T>>
 
 		gradientBackwardDifference(
 				Views.interval(Views.extend(input, fac), interval), output,
-				d);
+				dimension);
 
 	}
 	
@@ -73,7 +73,7 @@ public class DefaultBackwardDifference<T extends RealType<T>>
 		input.min(min);
 		input.max(max);
 
-		min[d] -= 1;
+		min[dimension] -= 1;
 		
 		interval = new FinalInterval(min, max);
 	}
@@ -90,11 +90,11 @@ public class DefaultBackwardDifference<T extends RealType<T>>
 	 *            gradient image plus a one pixel border in dimension.
 	 * @param gradient
 	 *            output image
-	 * @param dimension
+	 * @param dim
 	 *            along which dimension the partial derivatives are computed
 	 */
 	private void gradientBackwardDifference(final RandomAccessible<T> source,
-			final RandomAccessibleInterval<T> gradient, final int dimension) {
+			final RandomAccessibleInterval<T> gradient, final int dim) {
 		final int n = gradient.numDimensions();
 
 		final long[] min = new long[n];
@@ -106,12 +106,12 @@ public class DefaultBackwardDifference<T extends RealType<T>>
 			shiftback[d] = min[d] - max[d];
 
 		final RandomAccess<T> result = gradient.randomAccess();
-		final RandomAccess<T> back = source.randomAccess(Intervals.translate(gradient, 1, dimension));
+		final RandomAccess<T> back = source.randomAccess(Intervals.translate(gradient, 1, dim));
 		final RandomAccess<T> current = source.randomAccess(gradient);
 
 		result.setPosition(min);
 		back.setPosition(min);
-		back.bck(dimension);
+		back.bck(dim);
 		current.setPosition(min);
 
 		final long max0 = max[0];

--- a/src/main/java/net/imagej/ops/fopd/helper/DefaultDivergence3D.java
+++ b/src/main/java/net/imagej/ops/fopd/helper/DefaultDivergence3D.java
@@ -1,11 +1,6 @@
 package net.imagej.ops.fopd.helper;
 
-import org.scijava.Priority;
-import org.scijava.plugin.Parameter;
-import org.scijava.plugin.Plugin;
-
 import net.imagej.ops.OpService;
-import net.imagej.ops.fopd.DualVariables;
 import net.imagej.ops.special.function.Functions;
 import net.imagej.ops.special.function.UnaryFunctionOp;
 import net.imagej.ops.special.hybrid.AbstractUnaryHybridCF;
@@ -15,6 +10,10 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.outofbounds.OutOfBoundsConstantValueFactory;
 import net.imglib2.type.numeric.RealType;
 
+import org.scijava.Priority;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
 /**
  * 3D implementation of {@link Divergence}.
  * 
@@ -23,8 +22,8 @@ import net.imglib2.type.numeric.RealType;
  * @param <T>
  */
 @Plugin(type = Divergence.class, description = "3D Divergence.", priority = Priority.HIGH_PRIORITY)
-public class DefaultDivergence3D<T extends RealType<T>>
-		extends AbstractUnaryHybridCF<DualVariables<T>, RandomAccessibleInterval<T>> implements Divergence<T> {
+public class DefaultDivergence3D<T extends RealType<T>> extends
+		AbstractUnaryHybridCF<RandomAccessibleInterval<T>[], RandomAccessibleInterval<T>> implements Divergence<T> {
 
 	@Parameter
 	private OpService ops;
@@ -48,30 +47,30 @@ public class DefaultDivergence3D<T extends RealType<T>>
 	private UnaryFunctionOp<RandomAccessibleInterval, RandomAccessibleInterval> bdComputerZ;
 
 	@SuppressWarnings("unchecked")
-	public RandomAccessibleInterval<T> createOutput(DualVariables<T> input) {
-		return (RandomAccessibleInterval<T>) ops.create().img(input.getDualVariable(0));
+	public RandomAccessibleInterval<T> createOutput(RandomAccessibleInterval<T>[] input) {
+		return (RandomAccessibleInterval<T>) ops.create().img(input[0]);
 	}
 
 	@SuppressWarnings("unchecked")
-	public void compute(DualVariables<T> input, RandomAccessibleInterval<T> output) {
+	public void compute(RandomAccessibleInterval<T>[] input, RandomAccessibleInterval<T> output) {
 		if (bdComputerX == null || bdComputerY == null || bdComputerZ == null) {
 			init(input);
 		}
 
-		add3(bdComputerX.calculate(input.getDualVariable(0)), bdComputerY.calculate(input.getDualVariable(1)),
-				bdComputerZ.calculate(input.getDualVariable(2)), output);
+		add3(bdComputerX.calculate(input[0]), bdComputerY.calculate(input[1]), bdComputerZ.calculate(input[2]), output);
 	}
 
-	private void init(final DualVariables<T> input) {
+	private void init(final RandomAccessibleInterval<T>[] input) {
+		final T type = input[0].randomAccess().get().createVariable();
 		bdComputerX = Functions.unary(ops, DefaultBackwardDifference.class, RandomAccessibleInterval.class,
 				RandomAccessibleInterval.class, 0,
-				new OutOfBoundsConstantValueFactory<T, RandomAccessibleInterval<T>>(input.getType().createVariable()));
+				new OutOfBoundsConstantValueFactory<T, RandomAccessibleInterval<T>>(type));
 		bdComputerY = Functions.unary(ops, DefaultBackwardDifference.class, RandomAccessibleInterval.class,
 				RandomAccessibleInterval.class, 1,
-				new OutOfBoundsConstantValueFactory<T, RandomAccessibleInterval<T>>(input.getType().createVariable()));
+				new OutOfBoundsConstantValueFactory<T, RandomAccessibleInterval<T>>(type));
 		bdComputerZ = Functions.unary(ops, DefaultBackwardDifference.class, RandomAccessibleInterval.class,
 				RandomAccessibleInterval.class, 2,
-				new OutOfBoundsConstantValueFactory<T, RandomAccessibleInterval<T>>(input.getType().createVariable()));
+				new OutOfBoundsConstantValueFactory<T, RandomAccessibleInterval<T>>(type));
 	}
 
 	private void add3(final RandomAccessible<T> source0, final RandomAccessible<T> source1,

--- a/src/main/java/net/imagej/ops/fopd/helper/DefaultForwardDifference.java
+++ b/src/main/java/net/imagej/ops/fopd/helper/DefaultForwardDifference.java
@@ -1,9 +1,5 @@
 package net.imagej.ops.fopd.helper;
 
-import org.scijava.Priority;
-import org.scijava.plugin.Parameter;
-import org.scijava.plugin.Plugin;
-
 import net.imagej.ops.OpService;
 import net.imagej.ops.special.hybrid.AbstractUnaryHybridCF;
 import net.imglib2.FinalInterval;
@@ -14,6 +10,10 @@ import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.util.Intervals;
 import net.imglib2.view.Views;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
 
 /**
  * Implementation of {@link ForwardDifference} for the given dimension d.
@@ -28,7 +28,7 @@ public class DefaultForwardDifference<T extends RealType<T>>
 		implements ForwardDifference<T> {
 
 	@Parameter
-	private int d;
+	private int dimension;
 	
 	@Parameter
 	private OutOfBoundsFactory<T, RandomAccessibleInterval<T>> fac;
@@ -51,7 +51,7 @@ public class DefaultForwardDifference<T extends RealType<T>>
 		
 		gradientForwardDifference(
 				Views.interval(Views.extend(input, fac), interval), output,
-				d);
+				dimension);
 
 	}
 	
@@ -70,7 +70,7 @@ public class DefaultForwardDifference<T extends RealType<T>>
 		input.min(min);
 		input.max(max);
 
-		min[d] += 1;
+		min[dimension] += 1;
 		
 		interval = new FinalInterval(min, max);
 	}
@@ -87,11 +87,11 @@ public class DefaultForwardDifference<T extends RealType<T>>
 	 *            gradient image plus a one pixel border in dimension.
 	 * @param gradient
 	 *            output image
-	 * @param dimension
+	 * @param dim
 	 *            along which dimension the partial derivatives are computed
 	 */
 	private void gradientForwardDifference(final RandomAccessible<T> source,
-			final RandomAccessibleInterval<T> gradient, final int dimension) {
+			final RandomAccessibleInterval<T> gradient, final int dim) {
 		final int n = gradient.numDimensions();
 
 		final long[] min = new long[n];
@@ -103,12 +103,12 @@ public class DefaultForwardDifference<T extends RealType<T>>
 			shiftback[d] = min[d] - max[d];
 
 		final RandomAccess<T> result = gradient.randomAccess();
-		final RandomAccess<T> front = source.randomAccess(Intervals.translate(gradient, -1, dimension));
+		final RandomAccess<T> front = source.randomAccess(Intervals.translate(gradient, -1, dim));
 		final RandomAccess<T> current = source.randomAccess(gradient);
 
 		result.setPosition(min);
 		front.setPosition(min);
-		front.fwd(dimension);
+		front.fwd(dim);
 		current.setPosition(min);
 
 		final long max0 = max[0];

--- a/src/main/java/net/imagej/ops/fopd/helper/DefaultL2Norm.java
+++ b/src/main/java/net/imagej/ops/fopd/helper/DefaultL2Norm.java
@@ -2,7 +2,6 @@ package net.imagej.ops.fopd.helper;
 
 import net.imagej.ops.OpService;
 import net.imagej.ops.Ops.Stats.Sum;
-import net.imagej.ops.fopd.DualVariables;
 import net.imagej.ops.special.computer.Computers;
 import net.imagej.ops.special.hybrid.AbstractUnaryHybridCF;
 import net.imagej.ops.special.hybrid.BinaryHybridCF;
@@ -14,7 +13,6 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converter;
 import net.imglib2.converter.Converters;
 import net.imglib2.type.numeric.RealType;
-import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.view.Views;
 
 import org.scijava.plugin.Parameter;
@@ -29,7 +27,7 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = BinaryHybridCF.class)
 public class DefaultL2Norm<T extends RealType<T>>
-		extends AbstractUnaryHybridCF<DualVariables<T>, RandomAccessibleInterval<T>> implements L2Norm<T> {
+		extends AbstractUnaryHybridCF<RandomAccessibleInterval<T>[], RandomAccessibleInterval<T>> implements L2Norm<T> {
 
 	@Parameter
 	private OpService ops;
@@ -41,56 +39,67 @@ public class DefaultL2Norm<T extends RealType<T>>
 	private Converter<T, T> sqrtConverter;
 
 	@SuppressWarnings("unchecked")
-	public RandomAccessibleInterval<T> createOutput(final DualVariables<T> input) {
-		return (RandomAccessibleInterval<T>) ops.create().img(input.getDualVariable(0));
+	public RandomAccessibleInterval<T> createOutput(final RandomAccessibleInterval<T>[] input) {
+		return (RandomAccessibleInterval<T>) ops.create().img(input[0]);
 	}
 
-	public void compute(final DualVariables<T> input, final RandomAccessibleInterval<T> output) {
-		int numDualVariables = input.getNumDualVariables();
+	public void compute(final RandomAccessibleInterval<T>[] input, final RandomAccessibleInterval<T> output) {
+		int numDualVariables = input.length;
 
 		if (numDualVariables == 1) {
-			norm1D(input.getDualVariable(0), output);
+			norm1D(input[0], output);
 		} else if (numDualVariables == 2) {
-			norm2D(input.getDualVariable(0), input.getDualVariable(1), output);
+			norm2D(input[0], input[1], output);
 		} else if (numDualVariables == 3) {
-			norm3D(input.getDualVariable(0), input.getDualVariable(1), input.getDualVariable(2), output);
+			norm3D(input[0], input[1], input[2], output);
+		} else if (numDualVariables == 4) {
+			norm4D(input[0], input[1], input[2],
+					input[3], output);
 		} else {
 			normND(input, output);
 		}
 	}
 
 	@SuppressWarnings("unchecked")
-	private void normND(DualVariables<T> input, final RandomAccessibleInterval<T> output) {
-		final RandomAccessibleInterval<T> stack = Views.stack(input.getAllDUalVariables());
+	private void normND(final RandomAccessibleInterval<T>[] input, final RandomAccessibleInterval<T> output) {
+		final RandomAccessibleInterval<T> stack = Views.stack(input);
 
 		if (projector == null) {
-			init(stack, (IterableInterval<T>) output, input.getNumDualVariables() - 1);
+			init(stack, (IterableInterval<T>) output, input.length - 1);
 		}
 
-		projector.compute(Converters.convert(stack, squareConverter, input.getType()), (IterableInterval<T>) output);
+		final T type = input[0].randomAccess().get().createVariable();
+		projector.compute(Converters.convert(stack, squareConverter, type), (IterableInterval<T>) output);
 
-		Converters.convert(output, sqrtConverter, input.getType());
+		Converters.convert(output, sqrtConverter, type);
 	}
 
 	@SuppressWarnings("unchecked")
 	private void init(final RandomAccessibleInterval<T> stack, final IterableInterval<T> output, final int d) {
-		projector = ops.op(DefaultProjectParallel.class, IterableInterval.class, RandomAccessibleInterval.class,
-				Computers.unary(ops, Sum.class, DoubleType.class, RandomAccessibleInterval.class), d);
+		int[] tmpDims = new int[output.numDimensions()];
+		for (int i = 0; i < tmpDims.length; i++) {
+			tmpDims[i] += 1;
+		}
+		IterableInterval<T> tmpOut = (IterableInterval<T>) ops.create().img(output);
+		RandomAccessibleInterval<T> tmpStack = (RandomAccessibleInterval<T>) ops.create().img(stack);
+		projector = ops.op(DefaultProjectParallel.class, tmpOut, tmpStack,
+				Computers.unary(ops, Sum.class, output.firstElement().createVariable(), RandomAccessibleInterval.class),
+				d);
 
 		squareConverter = new Converter<T, T>() {
 
-			public void convert(T input, T output) {
-				final double value = input.getRealDouble();
-				output.setReal(value * value);
+			public void convert(T in, T out) {
+				final double value = in.getRealDouble();
+				out.setReal(value * value);
 			}
 
 		};
 
 		sqrtConverter = new Converter<T, T>() {
 
-			public void convert(T input, T output) {
-				final double value = input.getRealDouble();
-				output.setReal(Math.sqrt(value));
+			public void convert(T in, T out) {
+				final double value = in.getRealDouble();
+				out.setReal(Math.sqrt(value));
 			}
 
 		};
@@ -267,6 +276,80 @@ public class DefaultL2Norm<T extends RealType<T>>
 				s1.fwd(0);
 				s2.fwd(0);
 				s3.fwd(0);
+			}
+		}
+	}
+
+	private void norm4D(final RandomAccessible<T> source0, final RandomAccessible<T> source1,
+			final RandomAccessible<T> source2, final RandomAccessible<T> source3,
+			final RandomAccessibleInterval<T> norm) {
+		final int n = source0.numDimensions();
+
+		final long[] min = new long[n];
+		norm.min(min);
+		final long[] max = new long[n];
+		norm.max(max);
+		final long[] shiftback = new long[n];
+		for (int d = 0; d < n; ++d)
+			shiftback[d] = min[d] - max[d];
+
+		final RandomAccess<T> result = norm.randomAccess();
+		final RandomAccess<T> s1 = source0.randomAccess();
+		final RandomAccess<T> s2 = source1.randomAccess();
+		final RandomAccess<T> s3 = source2.randomAccess();
+		final RandomAccess<T> s4 = source3.randomAccess();
+
+		result.setPosition(min);
+		s1.setPosition(min);
+		s2.setPosition(min);
+		s3.setPosition(min);
+		s4.setPosition(min);
+
+		final long max0 = max[0];
+		while (true) {
+			// process pixel
+			final T t = result.get();
+			final double t1 = s1.get().getRealDouble();
+			final double t2 = s2.get().getRealDouble();
+			final double t3 = s3.get().getRealDouble();
+			final double t4 = s4.get().getRealDouble();
+			t.setReal(Math.sqrt(t1 * t1 + t2 * t2 + t3 * t3 + t4 * t4));
+
+			// move to next pixel
+			// check dimension 0 separately to avoid the loop over d in most
+			// iterations
+			if (result.getLongPosition(0) == max0) {
+				if (n == 1)
+					return;
+				result.move(shiftback[0], 0);
+				s1.move(shiftback[0], 0);
+				s2.move(shiftback[0], 0);
+				s3.move(shiftback[0], 0);
+				s4.move(shiftback[0], 0);
+				// now check the remaining dimensions
+				for (int d = 1; d < n; ++d)
+					if (result.getLongPosition(d) == max[d]) {
+						result.move(shiftback[d], d);
+						s1.move(shiftback[d], d);
+						s2.move(shiftback[d], d);
+						s3.move(shiftback[d], d);
+						s4.move(shiftback[d], d);
+						if (d == n - 1)
+							return;
+					} else {
+						result.fwd(d);
+						s1.fwd(d);
+						s2.fwd(d);
+						s3.fwd(d);
+						s4.fwd(d);
+						break;
+					}
+			} else {
+				result.fwd(0);
+				s1.fwd(0);
+				s2.fwd(0);
+				s3.fwd(0);
+				s4.fwd(0);
 			}
 		}
 	}

--- a/src/main/java/net/imagej/ops/fopd/helper/Divergence.java
+++ b/src/main/java/net/imagej/ops/fopd/helper/Divergence.java
@@ -1,6 +1,5 @@
 package net.imagej.ops.fopd.helper;
 
-import net.imagej.ops.fopd.DualVariables;
 import net.imagej.ops.special.hybrid.UnaryHybridCF;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
@@ -20,6 +19,6 @@ import net.imglib2.type.numeric.RealType;
  * @param <T>
  */
 public interface Divergence<T extends RealType<T>>
-		extends UnaryHybridCF<DualVariables<T>, RandomAccessibleInterval<T>> {
+		extends UnaryHybridCF<RandomAccessibleInterval<T>[], RandomAccessibleInterval<T>> {
 	// NB: Marker Interface
 }

--- a/src/main/java/net/imagej/ops/fopd/helper/L2Norm.java
+++ b/src/main/java/net/imagej/ops/fopd/helper/L2Norm.java
@@ -1,6 +1,5 @@
 package net.imagej.ops.fopd.helper;
 
-import net.imagej.ops.fopd.DualVariables;
 import net.imagej.ops.special.hybrid.UnaryHybridCF;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
@@ -17,6 +16,7 @@ import net.imglib2.type.numeric.RealType;
  *
  * @param <T>
  */
-public interface L2Norm<T extends RealType<T>> extends UnaryHybridCF<DualVariables<T>, RandomAccessibleInterval<T>> {
+public interface L2Norm<T extends RealType<T>>
+		extends UnaryHybridCF<RandomAccessibleInterval<T>[], RandomAccessibleInterval<T>> {
 	// NB: Marker Interface
 }

--- a/src/main/java/net/imagej/ops/fopd/regularizer/tgv/TGV2D.java
+++ b/src/main/java/net/imagej/ops/fopd/regularizer/tgv/TGV2D.java
@@ -1,0 +1,28 @@
+package net.imagej.ops.fopd.regularizer.tgv;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.fopd.regularizer.AbstractRegularizer;
+import net.imagej.ops.fopd.solver.SolverState;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * Total Generalized Variation implementation for one 2D image.
+ * 
+ * TGV(u), where u is the image which needs smoothing.
+ * 
+ * Ref: Bredies, Kristian, Karl Kunisch, and Thomas Pock.
+ * "Total generalized variation." SIAM Journal on Imaging Sciences 3.3 (2010):
+ * 492-526.
+ * 
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ */
+public class TGV2D<T extends RealType<T>> extends AbstractRegularizer<T> {
+
+	@SuppressWarnings("unchecked")
+	public TGV2D(final OpService ops, final double alpha, final double beta, final double descentStepSize) {
+		this.ascent = ops.op(TGV2DAscent.class, SolverState.class, alpha, beta);
+		this.descent = ops.op(TGV2DDescent.class, SolverState.class,
+				descentStepSize);
+	}
+}

--- a/src/main/java/net/imagej/ops/fopd/regularizer/tgv/TGV2DAscent.java
+++ b/src/main/java/net/imagej/ops/fopd/regularizer/tgv/TGV2DAscent.java
@@ -1,0 +1,217 @@
+package net.imagej.ops.fopd.regularizer.tgv;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops;
+import net.imagej.ops.Ops.Map;
+import net.imagej.ops.fopd.Ascent;
+import net.imagej.ops.fopd.DualVariables;
+import net.imagej.ops.fopd.helper.DefaultForwardDifference;
+import net.imagej.ops.fopd.helper.DefaultL1Projector;
+import net.imagej.ops.fopd.helper.DefaultL2Norm;
+import net.imagej.ops.fopd.regularizer.tgv.solver.TGVMinimizer2D;
+import net.imagej.ops.fopd.solver.RegularizerSolver;
+import net.imagej.ops.fopd.solver.SolverState;
+import net.imagej.ops.map.MapBinaryComputers.RAIAndRAIToIIParallel;
+import net.imagej.ops.map.MapBinaryInplace1s.IIAndIIParallel;
+import net.imagej.ops.special.computer.BinaryComputerOp;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
+import net.imagej.ops.special.function.Functions;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imagej.ops.special.inplace.BinaryInplace1Op;
+import net.imagej.ops.special.inplace.Inplaces;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.converter.Converter;
+import net.imglib2.converter.Converters;
+import net.imglib2.outofbounds.OutOfBoundsBorderFactory;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Total Generalized Variation of one 2D image: {@link Ascent} Step.
+ * 
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ * @param <T>
+ */
+@Plugin(type = Ascent.class)
+public class TGV2DAscent<T extends RealType<T>>
+		extends AbstractUnaryFunctionOp<SolverState<T>, SolverState<T>> implements Ascent<T> {
+
+	/**
+	 * The OpService.
+	 */
+	@Parameter
+	private OpService ops;
+
+	/**
+	 * Alpha weight.
+	 */
+	@Parameter
+	private double alpha;
+
+	/**
+	 * Beta weight.
+	 */
+	@Parameter
+	private double beta;
+
+	/**
+	 * The ascent step-size.
+	 */
+	private final double stepSize = 1 / 3.0;
+
+	/**
+	 * The norm of the input
+	 */
+	private RandomAccessibleInterval<T> norm;
+
+	/**
+	 * The gradient computer in X-direction.
+	 */
+	@SuppressWarnings("rawtypes")
+	private UnaryFunctionOp<RandomAccessibleInterval, RandomAccessibleInterval> gradientX;
+
+	/**
+	 * The gradient computer in Y-direction.
+	 */
+	@SuppressWarnings("rawtypes")
+	private UnaryFunctionOp<RandomAccessibleInterval, RandomAccessibleInterval> gradientY;
+
+	/**
+	 * Holds difference between current gradientX(resultImage) and the first result of the {@link TGVMinimizer2D}.
+	 */
+	private IterableInterval<T> diff0;
+	
+	/**
+	 * Holds difference between current gradientY(resultImage) and the second result of the {@link TGVMinimizer2D}.
+	 */
+	private IterableInterval<T> diff1;
+	
+	/**
+	 * Solver of the {@link TGVMinimizer2D} which has to do one iteration.
+	 */
+	private RegularizerSolver<T> tgvSolver;
+
+	/**
+	 * Add mapper.
+	 */
+	private RAIAndRAIToIIParallel<T, T, T> mapperAdd;
+
+	/**
+	 * Inplace mapper to project the dual-variable.
+	 */
+	private IIAndIIParallel<T, T> inplaceMapper;
+
+	/**
+	 * Norm computer.
+	 */
+	@SuppressWarnings("rawtypes")
+	private UnaryComputerOp<RandomAccessibleInterval[], RandomAccessibleInterval> normComputer;
+
+	/**
+	 * Converter which multiplies by stepSize.
+	 */
+	private Converter<T, T> c1;
+
+	/**
+	 * Converter which multiplies by stepSize.
+	 */
+	private Converter<T, T> c2;
+
+	/**
+	 * Subtract mapper.
+	 */
+	private RAIAndRAIToIIParallel<T, T, T> mapperSubtract;
+
+
+	@SuppressWarnings("unchecked")
+	public SolverState<T> calculate(final SolverState<T> input) {
+		final DualVariables<T> dualVariables = input.getRegularizerDV();
+
+		if (gradientX == null || gradientY == null || mapperAdd == null || norm == null) {
+			init(input);
+		}
+
+		mapperSubtract.compute(gradientX.calculate(input.getResultImage(0)), input.getSubSolverState(0).getResultImage(0),
+				diff0);
+
+		mapperAdd.compute(dualVariables.getDualVariable(0),
+				Converters.convert((RandomAccessibleInterval<T>)diff0, c1, input.getType()),
+				(IterableInterval<T>) dualVariables.getDualVariable(0));
+		
+		mapperSubtract.compute(gradientY.calculate(input.getResultImage(0)), input.getSubSolverState(0).getResultImage(1),
+				diff1);
+
+		mapperAdd.compute(
+				dualVariables.getDualVariable(1), Converters
+						.convert((RandomAccessibleInterval<T>)diff1, c2, input.getType()),
+				(IterableInterval<T>) dualVariables.getDualVariable(1));
+
+		normComputer.compute(dualVariables.getAllDualVariables(), norm);
+
+		inplaceMapper.mutate1((IterableInterval<T>) dualVariables.getDualVariable(0), (IterableInterval<T>) norm);
+		inplaceMapper.mutate1((IterableInterval<T>) dualVariables.getDualVariable(1), (IterableInterval<T>) norm);
+
+		tgvSolver.calculate(input);
+		
+		return input;
+	}
+
+	@SuppressWarnings("unchecked")
+	private void init(final SolverState<T> input) {
+		final DualVariables<T> dualVariables = input.getRegularizerDV();
+		norm = (RandomAccessibleInterval<T>) ops.create().img(dualVariables.getDualVariable(0));
+		diff0 = (IterableInterval<T>) ops.create().img(dualVariables.getDualVariable(0));
+		diff1 = (IterableInterval<T>) ops.create().img(dualVariables.getDualVariable(0));
+
+		gradientX = Functions.unary(ops, DefaultForwardDifference.class, RandomAccessibleInterval.class,
+				RandomAccessibleInterval.class, 0,
+				new OutOfBoundsBorderFactory<DoubleType, RandomAccessibleInterval<DoubleType>>());
+		gradientY = Functions.unary(ops, DefaultForwardDifference.class, RandomAccessibleInterval.class,
+				RandomAccessibleInterval.class, 1,
+				new OutOfBoundsBorderFactory<DoubleType, RandomAccessibleInterval<DoubleType>>());
+
+		c1 = new Converter<T, T>() {
+
+			public void convert(T in, T out) {
+				out.setReal(in.getRealDouble() * stepSize);
+			}
+		};
+
+		c2 = new Converter<T, T>() {
+
+			public void convert(T in, T out) {
+				out.setReal(in.getRealDouble() * stepSize);
+			}
+		};
+
+		final BinaryComputerOp<T, T, T> addComputer = Computers.binary(ops, Ops.Math.Add.class, input.getType(),
+				input.getType(), input.getType());
+
+		mapperAdd = (RAIAndRAIToIIParallel<T, T, T>) ops.op(Map.class, IterableInterval.class,
+				RandomAccessibleInterval.class, RandomAccessibleInterval.class, BinaryComputerOp.class);
+		mapperAdd.setOp(addComputer);
+
+		final BinaryComputerOp<T, T, T> subtractComputer = Computers.binary(ops, Ops.Math.Subtract.class,
+				input.getType(), input.getType(), input.getType());
+
+		mapperSubtract = (RAIAndRAIToIIParallel<T, T, T>) ops.op(Map.class, IterableInterval.class,
+				RandomAccessibleInterval.class, RandomAccessibleInterval.class, BinaryComputerOp.class);
+		mapperSubtract.setOp(subtractComputer);
+
+		inplaceMapper = (IIAndIIParallel<T, T>) ops.op(Map.class, IterableInterval.class, IterableInterval.class,
+				BinaryInplace1Op.class);
+
+		normComputer = Computers.unary(ops, DefaultL2Norm.class, RandomAccessibleInterval.class, RandomAccessibleInterval[].class);
+		inplaceMapper.setOp((BinaryInplace1Op<T, T, T>) Inplaces.binary1(ops, DefaultL1Projector.class,
+				input.getType(), input.getType(), alpha));
+		
+		tgvSolver = ops.op(RegularizerSolver.class, input.getSubSolverState(0), new TGVMinimizer2D<T>(ops, beta, 1/5.0), 1);
+	}
+}

--- a/src/main/java/net/imagej/ops/fopd/regularizer/tgv/TGV2DDescent.java
+++ b/src/main/java/net/imagej/ops/fopd/regularizer/tgv/TGV2DDescent.java
@@ -1,0 +1,84 @@
+package net.imagej.ops.fopd.regularizer.tgv;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops;
+import net.imagej.ops.Ops.Map;
+import net.imagej.ops.fopd.Descent;
+import net.imagej.ops.fopd.DualVariables;
+import net.imagej.ops.fopd.helper.DefaultDivergence2D;
+import net.imagej.ops.fopd.solver.SolverState;
+import net.imagej.ops.map.MapBinaryComputers.RAIAndRAIToIIParallel;
+import net.imagej.ops.special.computer.BinaryComputerOp;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
+import net.imagej.ops.special.function.Functions;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.converter.Converter;
+import net.imglib2.converter.Converters;
+import net.imglib2.type.numeric.RealType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Abstract Total Variation of one 2D image: {@link Descent} Step.
+ * 
+ * Note: Is the same for TV and TV-Huber.
+ * 
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ * @param <T>
+ */
+@Plugin(type = Descent.class)
+public class TGV2DDescent<T extends RealType<T>>
+		extends AbstractUnaryFunctionOp<SolverState<T>, SolverState<T>> implements Descent<T> {
+
+	@Parameter
+	private double stepSize;
+
+	@Parameter
+	private OpService ops;
+	@SuppressWarnings("rawtypes")
+	private UnaryFunctionOp<RandomAccessibleInterval[], RandomAccessibleInterval> divComputer;
+
+	private BinaryComputerOp<T, T, T> addComputer;
+
+	private RAIAndRAIToIIParallel<T, T, T> mapper;
+
+	private Converter<T, T> converter;
+
+	@SuppressWarnings("unchecked")
+	public SolverState<T> calculate(SolverState<T> input) {
+		final DualVariables<T> dualVariables = input.getRegularizerDV();
+
+		if (mapper == null || divComputer == null) {
+			init(dualVariables);
+		}
+
+		mapper.compute(input.getIntermediateResult(0),
+				Converters.convert(divComputer.calculate(dualVariables.getAllDualVariables()), converter,
+						input.getType()),
+				(IterableInterval<T>) input.getIntermediateResult(0));
+
+		return input;
+	}
+
+	@SuppressWarnings("unchecked")
+	private void init(final DualVariables<T> input) {
+		divComputer = Functions.unary(ops, DefaultDivergence2D.class, RandomAccessibleInterval.class,
+				RandomAccessibleInterval[].class);
+		converter = new Converter<T, T>() {
+
+			public void convert(T in, T out) {
+				out.setReal(in.getRealDouble() * stepSize);
+			}
+		};
+		addComputer = Computers.binary(ops, Ops.Math.Add.class, input.getType(), input.getType(), input.getType());
+		mapper = (RAIAndRAIToIIParallel<T, T, T>) ops.op(Map.class, IterableInterval.class,
+				RandomAccessibleInterval.class, RandomAccessibleInterval.class, BinaryComputerOp.class);
+		mapper.setOp(addComputer);
+
+	}
+}

--- a/src/main/java/net/imagej/ops/fopd/regularizer/tgv/solver/TGVMinimizer2D.java
+++ b/src/main/java/net/imagej/ops/fopd/regularizer/tgv/solver/TGVMinimizer2D.java
@@ -1,0 +1,28 @@
+package net.imagej.ops.fopd.regularizer.tgv.solver;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.fopd.regularizer.AbstractRegularizer;
+import net.imagej.ops.fopd.solver.SolverState;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * Total Generalized Variation as minimization problem for 2D images.
+ * 
+ * TGV(u), where u is the image which needs smoothing.
+ * 
+ * Ref: Bredies, Kristian, Karl Kunisch, and Thomas Pock.
+ * "Total generalized variation." SIAM Journal on Imaging Sciences 3.3 (2010):
+ * 492-526.
+ * 
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ */
+public class TGVMinimizer2D<T extends RealType<T>> extends AbstractRegularizer<T> {
+
+	@SuppressWarnings("unchecked")
+	public TGVMinimizer2D(final OpService ops, final double beta, final double descentStepSize) {
+		this.ascent = ops.op(TGVMinimizer2DAscent.class, SolverState.class, beta);
+		this.descent = ops.op(TGVMinimizer2DDescent.class, SolverState.class,
+				descentStepSize);
+	}
+}

--- a/src/main/java/net/imagej/ops/fopd/regularizer/tgv/solver/TGVMinimizer2DAscent.java
+++ b/src/main/java/net/imagej/ops/fopd/regularizer/tgv/solver/TGVMinimizer2DAscent.java
@@ -1,0 +1,204 @@
+package net.imagej.ops.fopd.regularizer.tgv.solver;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops;
+import net.imagej.ops.Ops.Map;
+import net.imagej.ops.fopd.Ascent;
+import net.imagej.ops.fopd.DualVariables;
+import net.imagej.ops.fopd.helper.DefaultForwardDifference;
+import net.imagej.ops.fopd.helper.DefaultL1Projector;
+import net.imagej.ops.fopd.helper.DefaultL2Norm;
+import net.imagej.ops.fopd.solver.SolverState;
+import net.imagej.ops.map.MapBinaryComputers.RAIAndRAIToIIParallel;
+import net.imagej.ops.map.MapBinaryInplace1s.IIAndIIParallel;
+import net.imagej.ops.special.computer.BinaryComputerOp;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
+import net.imagej.ops.special.function.Functions;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imagej.ops.special.inplace.BinaryInplace1Op;
+import net.imagej.ops.special.inplace.Inplaces;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.converter.Converter;
+import net.imglib2.converter.Converters;
+import net.imglib2.outofbounds.OutOfBoundsBorderFactory;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Total Generalized Variation of one 2D image: {@link Ascent} Step.
+ * 
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ * @param <T>
+ */
+@Plugin(type = Ascent.class)
+public class TGVMinimizer2DAscent<T extends RealType<T>> extends AbstractUnaryFunctionOp<SolverState<T>, SolverState<T>>
+		implements Ascent<T> {
+
+	/**
+	 * The OpService.
+	 */
+	@Parameter
+	private OpService ops;
+
+	/**
+	 * Weight-factor. 
+	 */
+	@Parameter
+	private double beta;
+
+	/**
+	 * StepSize for the ascent-step.
+	 */
+	private final double stepSizeTGV = 1 / 2.0;
+	
+	/**
+	 * Holds the gradient of the first image in x-direction.
+	 */
+	private RandomAccessibleInterval<T> g1xTGV;
+	
+	/**
+	 * Holds the gradient of the first image in y-direction.
+	 */
+	private RandomAccessibleInterval<T> g1yTGV;
+
+	/**
+	 * Holds the gradient of the second image in x-direction.
+	 */
+	private RandomAccessibleInterval<T> g2xTGV;
+	
+	/**
+	 * Holds the gradient of the second image in y-direction.
+	 */
+	private RandomAccessibleInterval<T> g2yTGV;
+
+	/**
+	 * The norm of the input
+	 */
+	private RandomAccessibleInterval<T> norm;
+
+	/**
+	 * The gradient computer in X-direction.
+	 */
+	@SuppressWarnings("rawtypes")
+	private UnaryFunctionOp<RandomAccessibleInterval, RandomAccessibleInterval> gradientX;
+
+	/**
+	 * The gradient computer in Y-direction.
+	 */
+	@SuppressWarnings("rawtypes")
+	private UnaryFunctionOp<RandomAccessibleInterval, RandomAccessibleInterval> gradientY;
+
+	/**
+	 * Add computer.
+	 */
+	private RAIAndRAIToIIParallel<T, T, T> mapperAdd;
+
+	/**
+	 * Norm computer.
+	 */
+	@SuppressWarnings("rawtypes")
+	private UnaryComputerOp<RandomAccessibleInterval[], RandomAccessibleInterval> normComputer;
+	
+	/**
+	 * Inplace mapper to project the dual variables back.
+	 */
+	private IIAndIIParallel<T, T> inplaceMapper;
+
+	/**
+	 * Converter multiplying by stepSizeTGV.
+	 */
+	private Converter<T, T> c1;
+
+	/**
+	 * Converter multiplying by 0.5*stepSizeTGV.
+	 */
+	private Converter<T, T> c2;
+
+	@SuppressWarnings("unchecked")
+	public SolverState<T> calculate(SolverState<T> input) {
+		final DualVariables<T> dualVariables = input.getSubSolverState(0).getRegularizerDV();
+
+		if (gradientX == null || gradientY == null || mapperAdd == null || normComputer == null || norm == null
+				|| inplaceMapper == null) {
+			init(input.getRegularizerDV());
+		}
+
+		g1xTGV = gradientX.calculate(input.getSubSolverState(0).getResultImage(0));
+		g1yTGV = gradientY.calculate(input.getSubSolverState(0).getResultImage(0));
+
+		g2xTGV = gradientX.calculate(input.getSubSolverState(0).getResultImage(1));
+		g2yTGV = gradientY.calculate(input.getSubSolverState(0).getResultImage(1));
+
+		mapperAdd.compute(dualVariables.getDualVariable(0), Converters.convert(g1xTGV, c1, input.getType()),
+				(IterableInterval<T>) dualVariables.getDualVariable(0));
+		mapperAdd.compute(dualVariables.getDualVariable(1), Converters.convert(g1yTGV, c2, input.getType()),
+				(IterableInterval<T>) dualVariables.getDualVariable(1));
+		mapperAdd.compute(dualVariables.getDualVariable(1), Converters.convert(g2xTGV, c2, input.getType()),
+				(IterableInterval<T>) dualVariables.getDualVariable(1));
+		mapperAdd.compute(dualVariables.getDualVariable(2), Converters.convert(g2yTGV, c1, input.getType()),
+				(IterableInterval<T>) dualVariables.getDualVariable(2));
+
+		normComputer.compute(new RandomAccessibleInterval[] { dualVariables.getDualVariable(0),
+				dualVariables.getDualVariable(1), dualVariables.getDualVariable(1), dualVariables.getDualVariable(2) },
+				norm);
+
+		inplaceMapper.mutate1((IterableInterval<T>) dualVariables.getDualVariable(0), (IterableInterval<T>) norm);
+		inplaceMapper.mutate1((IterableInterval<T>) dualVariables.getDualVariable(1), (IterableInterval<T>) norm);
+		inplaceMapper.mutate1((IterableInterval<T>) dualVariables.getDualVariable(2), (IterableInterval<T>) norm);
+
+		return input;
+	}
+
+	@SuppressWarnings("unchecked")
+	private void init(final DualVariables<T> input) {
+		norm = (RandomAccessibleInterval<T>) ops.create().img(input.getDualVariable(0));
+		g1xTGV = (RandomAccessibleInterval<T>) ops.create().img(input.getDualVariable(0));
+		g1yTGV = (RandomAccessibleInterval<T>) ops.create().img(input.getDualVariable(0));
+		g2xTGV = (RandomAccessibleInterval<T>) ops.create().img(input.getDualVariable(0));
+		g2yTGV = (RandomAccessibleInterval<T>) ops.create().img(input.getDualVariable(0));
+		gradientX = Functions.unary(ops, DefaultForwardDifference.class, RandomAccessibleInterval.class,
+				RandomAccessibleInterval.class, 0,
+				new OutOfBoundsBorderFactory<DoubleType, RandomAccessibleInterval<DoubleType>>());
+		gradientY = Functions.unary(ops, DefaultForwardDifference.class, RandomAccessibleInterval.class,
+				RandomAccessibleInterval.class, 1,
+				new OutOfBoundsBorderFactory<DoubleType, RandomAccessibleInterval<DoubleType>>());
+
+		c1 = new Converter<T, T>() {
+
+			public void convert(T in, T out) {
+				out.setReal(in.getRealDouble() * stepSizeTGV);
+			}
+		};
+
+		c2 = new Converter<T, T>() {
+
+			public void convert(T in, T out) {
+				out.setReal(in.getRealDouble() * stepSizeTGV * 0.5);
+			}
+		};
+
+		final BinaryComputerOp<T, T, T> addComputer = Computers.binary(ops, Ops.Math.Add.class, input.getType(),
+				input.getType(), input.getType());
+
+		mapperAdd = (RAIAndRAIToIIParallel<T, T, T>) ops.op(Map.class, IterableInterval.class,
+				RandomAccessibleInterval.class, RandomAccessibleInterval.class, BinaryComputerOp.class);
+		mapperAdd.setOp(addComputer);
+
+		inplaceMapper = (IIAndIIParallel<T, T>) ops.op(Map.class, IterableInterval.class, IterableInterval.class,
+				BinaryInplace1Op.class);
+
+		normComputer = Computers.unary(ops, DefaultL2Norm.class, RandomAccessibleInterval.class,
+				RandomAccessibleInterval[].class);
+		final BinaryInplace1Op<? super T, T, T> projector = Inplaces.binary1(ops, DefaultL1Projector.class,
+				input.getType(), input.getType(), beta);
+		inplaceMapper.setOp((BinaryInplace1Op<T, T, T>) projector);
+
+	}
+}

--- a/src/main/java/net/imagej/ops/fopd/regularizer/tgv/solver/TGVMinimizer2DDescent.java
+++ b/src/main/java/net/imagej/ops/fopd/regularizer/tgv/solver/TGVMinimizer2DDescent.java
@@ -1,0 +1,114 @@
+package net.imagej.ops.fopd.regularizer.tgv.solver;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops;
+import net.imagej.ops.Ops.Map;
+import net.imagej.ops.fopd.Descent;
+import net.imagej.ops.fopd.DualVariables;
+import net.imagej.ops.fopd.costfunction.CostFunction;
+import net.imagej.ops.fopd.helper.DefaultDivergence2D;
+import net.imagej.ops.fopd.solver.SolverState;
+import net.imagej.ops.map.MapBinaryComputers.RAIAndRAIToIIParallel;
+import net.imagej.ops.special.computer.BinaryComputerOp;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
+import net.imagej.ops.special.function.Functions;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.converter.Converter;
+import net.imglib2.converter.Converters;
+import net.imglib2.type.numeric.RealType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Total Generalized Variation of one 2D image: {@link Descent} Step.
+ * 
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ * @param <T>
+ */
+@Plugin(type = Descent.class)
+public class TGVMinimizer2DDescent<T extends RealType<T>>
+		extends AbstractUnaryFunctionOp<SolverState<T>, SolverState<T>> implements Descent<T> {
+
+	/**
+	 * Descent-stepSize, this depends on the {@link CostFunction}.
+	 */
+	@Parameter
+	private double stepSize;
+
+	/**
+	 * The {@link OpService}.
+	 */
+	@Parameter
+	private OpService ops;
+	
+	/**
+	 * Holds the sum of the divergence and the image which should be smoothed.
+	 */
+	private RandomAccessibleInterval<T> sum;
+
+	/**
+	 * Divergence computer.
+	 */
+	@SuppressWarnings("rawtypes")
+	private UnaryFunctionOp<RandomAccessibleInterval[], RandomAccessibleInterval> divComputer;
+
+	/**
+	 * Mapped add computer.
+	 */
+	private RAIAndRAIToIIParallel<T, T, T> mapperAdd;
+
+	/**
+	 * Converter multiplying by stepSize.
+	 */
+	private Converter<T, T> converter;
+
+
+	@SuppressWarnings("unchecked")
+	public SolverState<T> calculate(SolverState<T> input) {
+		final DualVariables<T> dualVariables = input.getSubSolverState(0).getRegularizerDV();
+
+		if (mapperAdd == null || divComputer == null) {
+			init(dualVariables);
+		}
+
+		mapperAdd.compute(
+				divComputer.calculate(new RandomAccessibleInterval[] { dualVariables.getDualVariable(0),
+						dualVariables.getDualVariable(1) }),
+				input.getRegularizerDV().getDualVariable(0), (IterableInterval<T>) sum);
+
+		mapperAdd.compute(input.getSubSolverState(0).getIntermediateResult(0), Converters.convert(sum, converter, input.getType()),
+				(IterableInterval<T>) input.getSubSolverState(0).getIntermediateResult(0));
+		
+		mapperAdd.compute(
+				divComputer.calculate(new RandomAccessibleInterval[] { dualVariables.getDualVariable(1),
+						dualVariables.getDualVariable(2) }),
+				input.getRegularizerDV().getDualVariable(1), (IterableInterval<T>) sum);
+
+		mapperAdd.compute(input.getSubSolverState(0).getIntermediateResult(1), Converters.convert(sum, converter, input.getType()),
+				(IterableInterval<T>) input.getSubSolverState(0).getIntermediateResult(1));
+
+		return input;
+	}
+
+	@SuppressWarnings("unchecked")
+	private void init(final DualVariables<T> input) {
+		divComputer = Functions.unary(ops, DefaultDivergence2D.class, RandomAccessibleInterval.class,
+				RandomAccessibleInterval[].class);
+		converter = new Converter<T, T>() {
+
+			public void convert(T in, T out) {
+				out.setReal(in.getRealDouble() * stepSize);
+			}
+		};
+		mapperAdd = (RAIAndRAIToIIParallel<T, T, T>) ops.op(Map.class, IterableInterval.class,
+				RandomAccessibleInterval.class, RandomAccessibleInterval.class, BinaryComputerOp.class);
+		mapperAdd.setOp(Computers.binary(ops, Ops.Math.Add.class, input.getType(), input.getType(), input.getType()));
+
+		sum = (RandomAccessibleInterval<T>) ops.create().img(input.getDualVariable(0));
+	}
+}

--- a/src/main/java/net/imagej/ops/fopd/regularizer/tgv/solver/TGVMinimizer2DSolverState.java
+++ b/src/main/java/net/imagej/ops/fopd/regularizer/tgv/solver/TGVMinimizer2DSolverState.java
@@ -1,0 +1,82 @@
+package net.imagej.ops.fopd.regularizer.tgv.solver;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.fopd.DualVariables;
+import net.imagej.ops.fopd.solver.SolverState;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link SolverState} for {@link TGVMinimizer2D}.
+ * 
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ * @param <T>
+ */
+public class TGVMinimizer2DSolverState<T extends RealType<T>> implements SolverState<T> {
+
+	private RandomAccessibleInterval<T>[] intermediateResults;
+
+	private RandomAccessibleInterval<T>[] results;
+
+	private DualVariables<T> regularizerDV;
+
+	private T type;
+
+	@SuppressWarnings("unchecked")
+	public TGVMinimizer2DSolverState(final OpService ops, final RandomAccessibleInterval<T> image) {
+
+		regularizerDV = new DualVariables<T>((RandomAccessibleInterval<T>) ops.create().img(image),
+				(RandomAccessibleInterval<T>) ops.create().img(image),
+				(RandomAccessibleInterval<T>) ops.create().img(image));
+
+		this.type = image.randomAccess().get().createVariable();
+
+		intermediateResults = new RandomAccessibleInterval[2];
+		intermediateResults[0] = (RandomAccessibleInterval<T>) ops.create().img(image);
+		intermediateResults[1] = (RandomAccessibleInterval<T>) ops.create().img(image);
+
+		this.results = new RandomAccessibleInterval[2];
+		results[0] = (RandomAccessibleInterval<T>) ops.create().img(image);
+		results[1] = (RandomAccessibleInterval<T>) ops.create().img(image);
+	}
+
+	public DualVariables<T> getRegularizerDV() {
+		return regularizerDV;
+	}
+
+	public DualVariables<T> getCostFunctionDV() {
+		throw new NullPointerException("This solver has no cost-function.");
+	}
+
+	public T getType() {
+		return this.type;
+	}
+
+	public RandomAccessibleInterval<T> getIntermediateResult(int i) {
+		if (i > 1) {
+			throw new ArrayIndexOutOfBoundsException("This solver only has two intermediate results.");
+		}
+		return intermediateResults[i];
+	}
+
+	public SolverState<T> getSubSolverState(int i) {
+		throw new NullPointerException("There is no sub-solver available.");
+	}
+
+	public RandomAccessibleInterval<T> getResultImage(int i) {
+		if (i > 1) {
+			throw new ArrayIndexOutOfBoundsException("This solver only has two results.");
+		}
+		return results[i];
+	}
+
+	public int numResultImages() {
+		return results.length;
+	}
+
+	public int numIntermediateResults() {
+		return intermediateResults.length;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/fopd/regularizer/tv/AbstractTV2DDescent.java
+++ b/src/main/java/net/imagej/ops/fopd/regularizer/tv/AbstractTV2DDescent.java
@@ -1,4 +1,4 @@
-package net.imagej.ops.fopd.regularizer;
+package net.imagej.ops.fopd.regularizer.tv;
 
 import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
@@ -6,12 +6,13 @@ import net.imagej.ops.Ops.Map;
 import net.imagej.ops.fopd.Descent;
 import net.imagej.ops.fopd.DualVariables;
 import net.imagej.ops.fopd.helper.DefaultDivergence2D;
+import net.imagej.ops.fopd.solver.SolverState;
 import net.imagej.ops.map.MapBinaryComputers.RAIAndRAIToIIParallel;
 import net.imagej.ops.special.computer.BinaryComputerOp;
 import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
 import net.imagej.ops.special.function.Functions;
 import net.imagej.ops.special.function.UnaryFunctionOp;
-import net.imagej.ops.special.hybrid.AbstractUnaryHybridCF;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converter;
@@ -32,14 +33,15 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Descent.class)
 public abstract class AbstractTV2DDescent<T extends RealType<T>>
-		extends AbstractUnaryHybridCF<DualVariables<T>, RandomAccessibleInterval<T>> implements Descent<T> {
+		extends AbstractUnaryFunctionOp<SolverState<T>, SolverState<T>> implements Descent<T> {
 
 	@Parameter
 	private double stepSize;
 
 	@Parameter
 	private OpService ops;
-	private UnaryFunctionOp<DualVariables, RandomAccessibleInterval> divComputer;
+	@SuppressWarnings("rawtypes")
+	private UnaryFunctionOp<RandomAccessibleInterval[], RandomAccessibleInterval> divComputer;
 
 	private BinaryComputerOp<T, T, T> addComputer;
 
@@ -47,28 +49,28 @@ public abstract class AbstractTV2DDescent<T extends RealType<T>>
 
 	private Converter<T, T> converter;
 
-	public RandomAccessibleInterval<T> createOutput(DualVariables<T> input) {
-		return (RandomAccessibleInterval<T>) ops.create().img(input.getDualVariable(0));
-	}
-
-	public void compute(DualVariables<T> input, RandomAccessibleInterval<T> output) {
+	@SuppressWarnings("unchecked")
+	public SolverState<T> calculate(SolverState<T> input) {
+		final DualVariables<T> dualVariables = input.getRegularizerDV();
 
 		if (mapper == null || divComputer == null) {
-			init(input);
+			init(dualVariables);
 		}
 
-		mapper.compute(output, Converters.convert(divComputer.calculate(input), converter, input.getType()),
-				(IterableInterval<T>) output);
-		;
+		mapper.compute(input.getIntermediateResult(0),
+				Converters.convert(divComputer.calculate(dualVariables.getAllDualVariables()), converter, input.getType()),
+				(IterableInterval<T>) input.getIntermediateResult(0));
+		return input;
 	}
 
+	@SuppressWarnings("unchecked")
 	private void init(final DualVariables<T> input) {
 		divComputer = Functions.unary(ops, DefaultDivergence2D.class, RandomAccessibleInterval.class,
-				DualVariables.class);
+				RandomAccessibleInterval[].class);
 		converter = new Converter<T, T>() {
 
-			public void convert(T input, T output) {
-				output.setReal(input.getRealDouble() * stepSize);
+			public void convert(T in, T out) {
+				out.setReal(in.getRealDouble() * stepSize);
 			}
 		};
 		addComputer = Computers.binary(ops, Ops.Math.Add.class, input.getType(), input.getType(), input.getType());

--- a/src/main/java/net/imagej/ops/fopd/regularizer/tv/TotalVariation2D.java
+++ b/src/main/java/net/imagej/ops/fopd/regularizer/tv/TotalVariation2D.java
@@ -1,8 +1,8 @@
-package net.imagej.ops.fopd.regularizer;
+package net.imagej.ops.fopd.regularizer.tv;
 
 import net.imagej.ops.OpService;
-import net.imagej.ops.fopd.DualVariables;
-import net.imglib2.RandomAccessibleInterval;
+import net.imagej.ops.fopd.regularizer.AbstractRegularizer;
+import net.imagej.ops.fopd.solver.SolverState;
 import net.imglib2.type.numeric.RealType;
 
 /**
@@ -21,8 +21,8 @@ public class TotalVariation2D<T extends RealType<T>> extends AbstractRegularizer
 
 	@SuppressWarnings("unchecked")
 	public TotalVariation2D(final OpService ops, final double lambda, final double descentStepSize) {
-		this.ascent = ops.op(TotalVariation2DAscent.class, RandomAccessibleInterval.class, DualVariables.class, lambda);
-		this.descent = ops.op(TotalVariation2DDescent.class, RandomAccessibleInterval.class, DualVariables.class,
+		this.ascent = ops.op(TotalVariation2DAscent.class, SolverState.class, lambda);
+		this.descent = ops.op(TotalVariation2DDescent.class, SolverState.class,
 				descentStepSize);
 	}
 }

--- a/src/main/java/net/imagej/ops/fopd/regularizer/tv/TotalVariation2DAscent.java
+++ b/src/main/java/net/imagej/ops/fopd/regularizer/tv/TotalVariation2DAscent.java
@@ -1,4 +1,4 @@
-package net.imagej.ops.fopd.regularizer;
+package net.imagej.ops.fopd.regularizer.tv;
 
 import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
@@ -8,14 +8,15 @@ import net.imagej.ops.fopd.DualVariables;
 import net.imagej.ops.fopd.helper.DefaultForwardDifference;
 import net.imagej.ops.fopd.helper.DefaultL1Projector;
 import net.imagej.ops.fopd.helper.DefaultL2Norm;
+import net.imagej.ops.fopd.solver.SolverState;
 import net.imagej.ops.map.MapBinaryComputers.RAIAndRAIToIIParallel;
 import net.imagej.ops.map.MapBinaryInplace1s.IIAndIIParallel;
 import net.imagej.ops.special.computer.BinaryComputerOp;
 import net.imagej.ops.special.computer.Computers;
 import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
 import net.imagej.ops.special.function.Functions;
 import net.imagej.ops.special.function.UnaryFunctionOp;
-import net.imagej.ops.special.hybrid.AbstractUnaryHybridCF;
 import net.imagej.ops.special.inplace.BinaryInplace1Op;
 import net.imagej.ops.special.inplace.Inplaces;
 import net.imglib2.IterableInterval;
@@ -38,7 +39,7 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ascent.class)
 public class TotalVariation2DAscent<T extends RealType<T>>
-		extends AbstractUnaryHybridCF<DualVariables<T>, RandomAccessibleInterval<T>> implements Ascent<T> {
+		extends AbstractUnaryFunctionOp<SolverState<T>, SolverState<T>> implements Ascent<T> {
 
 	/**
 	 * The OpService.
@@ -62,47 +63,49 @@ public class TotalVariation2DAscent<T extends RealType<T>>
 	/**
 	 * The gradient computer in X-direction.
 	 */
+	@SuppressWarnings("rawtypes")
 	private UnaryFunctionOp<RandomAccessibleInterval, RandomAccessibleInterval> gradientX;
 
 	/**
 	 * The gradient computer in Y-direction.
 	 */
+	@SuppressWarnings("rawtypes")
 	private UnaryFunctionOp<RandomAccessibleInterval, RandomAccessibleInterval> gradientY;
 
 	private RAIAndRAIToIIParallel<T, T, T> mapper;
 	
 	private IIAndIIParallel<T,T> inplaceMapper;
 
-	private UnaryComputerOp<DualVariables, RandomAccessibleInterval> normComputer;
+	@SuppressWarnings("rawtypes")
+	private UnaryComputerOp<RandomAccessibleInterval[], RandomAccessibleInterval> normComputer;
 
 	private Converter<T, T> c1;
 
 	private Converter<T, T> c2;
 
-	public RandomAccessibleInterval<T> createOutput(DualVariables<T> input) {
+	@SuppressWarnings("unchecked")
+	public SolverState<T> calculate(SolverState<T> input) {
+		final DualVariables<T> dualVariables = input.getRegularizerDV();
+
+		if (gradientX == null || gradientY == null || mapper == null || norm == null) {
+			init(dualVariables);
+		}
+
+		mapper.compute(dualVariables.getDualVariable(0), (RandomAccessibleInterval<T>) Converters
+				.convert(gradientX.calculate(input.getResultImage(0)), c1, input.getType()), (IterableInterval<T>) dualVariables.getDualVariable(0));
+
+		mapper.compute(dualVariables.getDualVariable(1), (RandomAccessibleInterval<T>) Converters
+				.convert(gradientY.calculate(input.getResultImage(0)), c2, input.getType()), (IterableInterval<T>) dualVariables.getDualVariable(1));
+
+		normComputer.compute(dualVariables.getAllDualVariables(), norm);
 		
-		return (RandomAccessibleInterval<T>) ops.create().img(input.getDualVariable(0));
+		inplaceMapper.mutate1((IterableInterval<T>)dualVariables.getDualVariable(0), (IterableInterval<T>)norm);
+		inplaceMapper.mutate1((IterableInterval<T>)dualVariables.getDualVariable(1), (IterableInterval<T>)norm);
+		
+		return input;
 	}
 
 	@SuppressWarnings("unchecked")
-	public void compute(DualVariables<T> input, RandomAccessibleInterval<T> output) {
-
-		if (gradientX == null || gradientY == null || mapper == null || norm == null) {
-			init(input);
-		}
-
-		mapper.compute(input.getDualVariable(0), (RandomAccessibleInterval<T>) Converters
-				.convert(gradientX.calculate(output), c1, input.getType()), (IterableInterval<T>) input.getDualVariable(0));
-
-		mapper.compute(input.getDualVariable(1), (RandomAccessibleInterval<T>) Converters
-				.convert(gradientY.calculate(output), c2, input.getType()), (IterableInterval<T>) input.getDualVariable(1));
-
-		normComputer.compute(input, norm);
-		
-		inplaceMapper.mutate1((IterableInterval<T>)input.getDualVariable(0), (IterableInterval<T>)norm);
-		inplaceMapper.mutate1((IterableInterval<T>)input.getDualVariable(1), (IterableInterval<T>)norm);
-	}
-
 	private void init(final DualVariables<T> input) {
 		norm = (RandomAccessibleInterval<T>) ops.create().img(input.getDualVariable(0));
 		gradientX = Functions.unary(ops, DefaultForwardDifference.class, RandomAccessibleInterval.class,
@@ -134,7 +137,7 @@ public class TotalVariation2DAscent<T extends RealType<T>>
 		
 		inplaceMapper = (IIAndIIParallel<T,T>) ops.op(Map.class, IterableInterval.class, IterableInterval.class, BinaryInplace1Op.class);
 		
-		normComputer = Computers.unary(ops, DefaultL2Norm.class, RandomAccessibleInterval.class, DualVariables.class);
+		normComputer = Computers.unary(ops, DefaultL2Norm.class, RandomAccessibleInterval.class, RandomAccessibleInterval[].class);
 		final BinaryInplace1Op<? super T, T, T> projector = Inplaces.binary1(ops, DefaultL1Projector.class, input.getType(), input.getType(), lambda);
 		inplaceMapper.setOp((BinaryInplace1Op<T, T, T>) projector);
 

--- a/src/main/java/net/imagej/ops/fopd/regularizer/tv/TotalVariation2DDescent.java
+++ b/src/main/java/net/imagej/ops/fopd/regularizer/tv/TotalVariation2DDescent.java
@@ -1,4 +1,4 @@
-package net.imagej.ops.fopd.regularizer;
+package net.imagej.ops.fopd.regularizer.tv;
 
 import net.imagej.ops.fopd.Descent;
 import net.imglib2.type.numeric.RealType;

--- a/src/main/java/net/imagej/ops/fopd/regularizer/tvhuber/TVHuber2D.java
+++ b/src/main/java/net/imagej/ops/fopd/regularizer/tvhuber/TVHuber2D.java
@@ -1,8 +1,9 @@
-package net.imagej.ops.fopd.regularizer;
+package net.imagej.ops.fopd.regularizer.tvhuber;
 
 import net.imagej.ops.OpService;
-import net.imagej.ops.fopd.DualVariables;
-import net.imglib2.RandomAccessibleInterval;
+import net.imagej.ops.fopd.regularizer.AbstractRegularizer;
+import net.imagej.ops.fopd.regularizer.tv.TotalVariation2DDescent;
+import net.imagej.ops.fopd.solver.SolverState;
 import net.imglib2.type.numeric.RealType;
 
 /**
@@ -20,8 +21,8 @@ public class TVHuber2D<T extends RealType<T>> extends AbstractRegularizer<T> {
 
 	@SuppressWarnings("unchecked")
 	public TVHuber2D(final OpService ops, final double lambda, final double alpha, final double descentStepSize) {
-		this.ascent = ops.op(TVHuber2DAscent.class, RandomAccessibleInterval.class, DualVariables.class, lambda, alpha);
-		this.descent = ops.op(TotalVariation2DDescent.class, RandomAccessibleInterval.class, DualVariables.class,
+		this.ascent = ops.op(TVHuber2DAscent.class, SolverState.class, lambda, alpha);
+		this.descent = ops.op(TotalVariation2DDescent.class, SolverState.class,
 				descentStepSize);
 	}
 }

--- a/src/main/java/net/imagej/ops/fopd/regularizer/tvhuber/TVHuber2DAscent.java
+++ b/src/main/java/net/imagej/ops/fopd/regularizer/tvhuber/TVHuber2DAscent.java
@@ -1,4 +1,4 @@
-package net.imagej.ops.fopd.regularizer;
+package net.imagej.ops.fopd.regularizer.tvhuber;
 
 import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
@@ -8,15 +8,16 @@ import net.imagej.ops.fopd.DualVariables;
 import net.imagej.ops.fopd.helper.DefaultForwardDifference;
 import net.imagej.ops.fopd.helper.DefaultL1Projector;
 import net.imagej.ops.fopd.helper.DefaultL2Norm;
+import net.imagej.ops.fopd.solver.SolverState;
 import net.imagej.ops.map.MapBinaryComputers.RAIAndRAIToIIParallel;
 import net.imagej.ops.map.MapBinaryInplace1s.IIAndIIParallel;
 import net.imagej.ops.map.MapUnaryComputers.IIToIIParallel;
 import net.imagej.ops.special.computer.BinaryComputerOp;
 import net.imagej.ops.special.computer.Computers;
 import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
 import net.imagej.ops.special.function.Functions;
 import net.imagej.ops.special.function.UnaryFunctionOp;
-import net.imagej.ops.special.hybrid.AbstractUnaryHybridCF;
 import net.imagej.ops.special.inplace.BinaryInplace1Op;
 import net.imagej.ops.special.inplace.Inplaces;
 import net.imglib2.IterableInterval;
@@ -39,7 +40,7 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ascent.class)
 public class TVHuber2DAscent<T extends RealType<T>>
-		extends AbstractUnaryHybridCF<DualVariables<T>, RandomAccessibleInterval<T>> implements Ascent<T> {
+		extends AbstractUnaryFunctionOp<SolverState<T>, SolverState<T>> implements Ascent<T> {
 
 	/**
 	 * The OpService.
@@ -66,18 +67,21 @@ public class TVHuber2DAscent<T extends RealType<T>>
 	/**
 	 * The gradient computer in X-direction.
 	 */
+	@SuppressWarnings("rawtypes")
 	private UnaryFunctionOp<RandomAccessibleInterval, RandomAccessibleInterval> gradientX;
 
 	/**
 	 * The gradient computer in Y-direction.
 	 */
+	@SuppressWarnings("rawtypes")
 	private UnaryFunctionOp<RandomAccessibleInterval, RandomAccessibleInterval> gradientY;
 
 	private RAIAndRAIToIIParallel<T, T, T> mapperAdd;
 
 	private IIAndIIParallel<T, T> inplaceMapper;
 
-	private UnaryComputerOp<DualVariables, RandomAccessibleInterval> normComputer;
+	@SuppressWarnings("rawtypes")
+	private UnaryComputerOp<RandomAccessibleInterval[], RandomAccessibleInterval> normComputer;
 
 	private IIToIIParallel<T, T> mapperDivide;
 
@@ -85,37 +89,36 @@ public class TVHuber2DAscent<T extends RealType<T>>
 
 	private Converter<T, T> c2;
 
-	public RandomAccessibleInterval<T> createOutput(DualVariables<T> input) {
+	@SuppressWarnings("unchecked")
+	public SolverState<T> calculate(SolverState<T> input) {
+		final DualVariables<T> dualVariables = input.getRegularizerDV();
 
-		return (RandomAccessibleInterval<T>) ops.create().img(input.getDualVariable(0));
+		if (gradientX == null || gradientY == null || mapperAdd == null || norm == null) {
+			init(dualVariables);
+		}
+
+		mapperAdd.compute(dualVariables.getDualVariable(0),
+				(RandomAccessibleInterval<T>) Converters.convert(gradientX.calculate(input.getResultImage(0)), c1, input.getType()),
+				(IterableInterval<T>) dualVariables.getDualVariable(0));
+
+		mapperAdd.compute(dualVariables.getDualVariable(1),
+				(RandomAccessibleInterval<T>) Converters.convert(gradientY.calculate(input.getResultImage(0)), c2, input.getType()),
+				(IterableInterval<T>) dualVariables.getDualVariable(1));
+
+		mapperDivide.compute((IterableInterval<T>) dualVariables.getDualVariable(0),
+				(IterableInterval<T>) dualVariables.getDualVariable(0));
+		mapperDivide.compute((IterableInterval<T>) dualVariables.getDualVariable(1),
+				(IterableInterval<T>) dualVariables.getDualVariable(1));
+
+		normComputer.compute(dualVariables.getAllDualVariables(), norm);
+
+		inplaceMapper.mutate1((IterableInterval<T>) dualVariables.getDualVariable(0), (IterableInterval<T>) norm);
+		inplaceMapper.mutate1((IterableInterval<T>) dualVariables.getDualVariable(1), (IterableInterval<T>) norm);
+		
+		return input;
 	}
 
 	@SuppressWarnings("unchecked")
-	public void compute(DualVariables<T> input, RandomAccessibleInterval<T> output) {
-
-		if (gradientX == null || gradientY == null || mapperAdd == null || norm == null) {
-			init(input);
-		}
-
-		mapperAdd.compute(input.getDualVariable(0),
-				(RandomAccessibleInterval<T>) Converters.convert(gradientX.calculate(output), c1, input.getType()),
-				(IterableInterval<T>) input.getDualVariable(0));
-
-		mapperAdd.compute(input.getDualVariable(1),
-				(RandomAccessibleInterval<T>) Converters.convert(gradientY.calculate(output), c2, input.getType()),
-				(IterableInterval<T>) input.getDualVariable(1));
-
-		mapperDivide.compute((IterableInterval<T>) input.getDualVariable(0),
-				(IterableInterval<T>) input.getDualVariable(0));
-		mapperDivide.compute((IterableInterval<T>) input.getDualVariable(1),
-				(IterableInterval<T>) input.getDualVariable(1));
-
-		normComputer.compute(input, norm);
-
-		inplaceMapper.mutate1((IterableInterval<T>) input.getDualVariable(0), (IterableInterval<T>) norm);
-		inplaceMapper.mutate1((IterableInterval<T>) input.getDualVariable(1), (IterableInterval<T>) norm);
-	}
-
 	private void init(final DualVariables<T> input) {
 		norm = (RandomAccessibleInterval<T>) ops.create().img(input.getDualVariable(0));
 		gradientX = Functions.unary(ops, DefaultForwardDifference.class, RandomAccessibleInterval.class,
@@ -148,12 +151,12 @@ public class TVHuber2DAscent<T extends RealType<T>>
 		mapperDivide = (IIToIIParallel<T, T>) ops.op(Map.class, IterableInterval.class, IterableInterval.class,
 				UnaryComputerOp.class);
 		mapperDivide
-				.setOp((UnaryComputerOp<T, T>) Computers.unary(ops, Ops.Math.Divide.class, input.getType(), divider));
+				.setOp(Computers.unary(ops, Ops.Math.Divide.class, input.getType(), divider));
 
 		inplaceMapper = (IIAndIIParallel<T, T>) ops.op(Map.class, IterableInterval.class, IterableInterval.class,
 				BinaryInplace1Op.class);
 
-		normComputer = Computers.unary(ops, DefaultL2Norm.class, RandomAccessibleInterval.class, DualVariables.class);
+		normComputer = Computers.unary(ops, DefaultL2Norm.class, RandomAccessibleInterval.class, RandomAccessibleInterval[].class);
 		inplaceMapper.setOp((BinaryInplace1Op<T, T, T>) Inplaces.binary1(ops, DefaultL1Projector.class, input.getType(),
 				input.getType(), lambda));
 

--- a/src/main/java/net/imagej/ops/fopd/regularizer/tvhuber/TVHuber2DDescent.java
+++ b/src/main/java/net/imagej/ops/fopd/regularizer/tvhuber/TVHuber2DDescent.java
@@ -1,6 +1,7 @@
-package net.imagej.ops.fopd.regularizer;
+package net.imagej.ops.fopd.regularizer.tvhuber;
 
 import net.imagej.ops.fopd.Descent;
+import net.imagej.ops.fopd.regularizer.tv.AbstractTV2DDescent;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.plugin.Plugin;

--- a/src/main/java/net/imagej/ops/fopd/solver/RegularizerSolver.java
+++ b/src/main/java/net/imagej/ops/fopd/solver/RegularizerSolver.java
@@ -1,0 +1,122 @@
+package net.imagej.ops.fopd.solver;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops;
+import net.imagej.ops.Ops.Map;
+import net.imagej.ops.fopd.helper.Default01Clipper;
+import net.imagej.ops.fopd.regularizer.Regularizer;
+import net.imagej.ops.map.MapBinaryComputers.RAIAndIIToRAIParallel;
+import net.imagej.ops.map.MapIIInplaceParallel;
+import net.imagej.ops.special.computer.BinaryComputerOp;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
+import net.imagej.ops.special.inplace.Inplaces;
+import net.imagej.ops.special.inplace.UnaryInplaceOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.converter.Converter;
+import net.imglib2.converter.Converters;
+import net.imglib2.type.numeric.RealType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * This {@link Solver} is an implementation of the algorithm proposed by:
+ * Chambolle, Antonin, and Thomas Pock.
+ * "A first-order primal-dual algorithm for convex problems with applications to imaging."
+ * Journal of Mathematical Imaging and Vision 40.1 (2011): 120-145.
+ * 
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ * @param <T>
+ */
+@Plugin(type = Solver.class)
+public class RegularizerSolver<T extends RealType<T>>
+		extends AbstractUnaryFunctionOp<SolverState<T>, RandomAccessibleInterval<T>> implements Solver<T> {
+
+	@Parameter
+	private Regularizer<T> regularizer;
+
+	@Parameter
+	private int numIterations;
+
+	@Parameter
+	private OpService ops;
+
+	/**
+	 * CopyComputer to copy images.
+	 */
+	private UnaryComputerOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> copyComputer;
+
+	/**
+	 * Subtract computer.
+	 */
+	private RAIAndIIToRAIParallel<T, T, T> mapperSubtract;
+
+	/**
+	 * [0, 1]-Clipper.
+	 */
+	private MapIIInplaceParallel<T> clipperMapper;
+
+	private Converter<T, T> converter;
+
+	@SuppressWarnings("unchecked")
+	public RandomAccessibleInterval<T> calculate(SolverState<T> input) {
+
+		if (mapperSubtract == null || copyComputer == null || converter == null || clipperMapper == null) {
+			initComputers(input);
+		}
+
+		// only needed because of a matcher bug.
+		final RandomAccessibleInterval<T> tmp = (RandomAccessibleInterval<T>) ops.create()
+				.img(input.getIntermediateResult(0));
+
+		for (int i = 0; i < numIterations; i++) {
+
+			regularizer.getAscent().calculate(input);
+			for (int j = 0; j < input.getSubSolverState(0).numIntermediateResults(); j++) {
+				copyComputer.compute(input.getSubSolverState(0).getIntermediateResult(j),
+						input.getSubSolverState(0).getResultImage(j));
+			}
+			regularizer.getDescent().calculate(input);
+
+			for (int j = 0; j < input.getSubSolverState(0).numIntermediateResults(); j++) {
+				// mapperSubtract.compute(2*u, uq, uq) does not work, because
+				// wrong
+				// map is chosen later on.
+				mapperSubtract.compute(
+						Converters.convert(input.getSubSolverState(0).getIntermediateResult(j), converter,
+								input.getRegularizerDV().getType()),
+						(IterableInterval<T>) input.getSubSolverState(0).getResultImage(j), tmp);
+
+				copyComputer.compute(tmp, input.getSubSolverState(0).getResultImage(j));
+				clipperMapper.mutate((IterableInterval<T>) input.getSubSolverState(0).getResultImage(j));
+			}
+		}
+		return input.getSubSolverState(0).getResultImage(0);
+	}
+
+	@SuppressWarnings("unchecked")
+	private void initComputers(final SolverState<T> input) {
+		final T type = input.getType();
+
+		mapperSubtract = (RAIAndIIToRAIParallel<T, T, T>) ops.op(Map.class, RandomAccessibleInterval.class,
+				RandomAccessibleInterval.class, IterableInterval.class, BinaryComputerOp.class);
+		mapperSubtract.setOp(Computers.binary(ops, Ops.Math.Subtract.class, type, type, type));
+
+		copyComputer = Computers.unary(ops, Ops.Copy.RAI.class, input.getResultImage(0), input.getResultImage(0));
+
+		converter = new Converter<T, T>() {
+
+			public void convert(T in, T output) {
+				output.setReal(in.getRealDouble() * 2.0);
+			}
+
+		};
+
+		clipperMapper = (MapIIInplaceParallel<T>) ops.op(Map.class, IterableInterval.class, UnaryInplaceOp.class);
+		clipperMapper.setOp((UnaryInplaceOp<T, T>) Inplaces.unary(ops, Default01Clipper.class, type));
+	}
+}

--- a/src/main/java/net/imagej/ops/fopd/solver/Solver.java
+++ b/src/main/java/net/imagej/ops/fopd/solver/Solver.java
@@ -1,6 +1,6 @@
 package net.imagej.ops.fopd.solver;
 
-import net.imagej.ops.special.hybrid.UnaryHybridCF;
+import net.imagej.ops.special.function.UnaryFunctionOp;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
@@ -10,6 +10,6 @@ import net.imglib2.type.numeric.RealType;
  *
  * @param <T>
  */
-public interface Solver<T extends RealType<T>> extends UnaryHybridCF<SolverState<T>, RandomAccessibleInterval<T>> {
+public interface Solver<T extends RealType<T>> extends UnaryFunctionOp<SolverState<T>, RandomAccessibleInterval<T>> {
 	// NB: Marker Interface
 }

--- a/src/main/java/net/imagej/ops/fopd/solver/SolverState.java
+++ b/src/main/java/net/imagej/ops/fopd/solver/SolverState.java
@@ -12,23 +12,6 @@ import net.imglib2.type.numeric.RealType;
  * @param <T>
  */
 public interface SolverState<T extends RealType<T>> {
-	/**
-	 * 
-	 * @return number of iterations
-	 */
-	int getNumIterations();
-
-	/**
-	 * 
-	 * @return smoothness weight
-	 */
-	double getLambda();
-
-	/**
-	 * 
-	 * @return the observed image
-	 */
-	RandomAccessibleInterval<T> getImage();
 
 	/**
 	 * 
@@ -52,5 +35,13 @@ public interface SolverState<T extends RealType<T>> {
 	 * 
 	 * @return the intermediate result of the solver
 	 */
-	RandomAccessibleInterval<T> getIntermediateResult();
+	RandomAccessibleInterval<T> getIntermediateResult(final int i);
+	
+	SolverState<T> getSubSolverState(final int i);
+	
+	RandomAccessibleInterval<T> getResultImage(final int i);
+	
+	int numResultImages();
+	
+	int numIntermediateResults();
 }

--- a/src/main/java/net/imagej/ops/fopd/solver/TGVL1DenoisingSolverState.java
+++ b/src/main/java/net/imagej/ops/fopd/solver/TGVL1DenoisingSolverState.java
@@ -1,0 +1,86 @@
+package net.imagej.ops.fopd.solver;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.fopd.DualVariables;
+import net.imagej.ops.fopd.regularizer.tgv.solver.TGVMinimizer2DSolverState;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * Specific implementation of {@link SolverState} for L1-TV-Denoising.
+ * 
+ * Energy: E(u) = lambda * TV(u) + |u - f|_1, where u is the denoised solution,
+ * lambda is the smoothness weight and f is the observed image.
+ * 
+ * @author Tim-Oliver Buchholz, University of Konstanz.
+ *
+ * @param <T>
+ */
+public class TGVL1DenoisingSolverState<T extends RealType<T>> implements SolverState<T> {
+
+	private DualVariables<T> regularizerDV;
+
+	private DualVariables<T> costFunctionDV;
+
+	private RandomAccessibleInterval<T> tmp;
+
+	private RandomAccessibleInterval<T> result;
+	
+	private TGVMinimizer2DSolverState<T> tgvState;
+
+	private T type;
+
+	@SuppressWarnings("unchecked")
+	public TGVL1DenoisingSolverState(final OpService ops, final RandomAccessibleInterval<T> image) {
+
+		this.regularizerDV = new DualVariables<T>((RandomAccessibleInterval<T>) ops.create().img(image),
+				(RandomAccessibleInterval<T>) ops.create().img(image));
+		this.costFunctionDV = new DualVariables<T>((RandomAccessibleInterval<T>) ops.create().img(image));
+
+		this.tmp = (RandomAccessibleInterval<T>) ops.create().img(image);
+		this.result = (RandomAccessibleInterval<T>) ops.create().img(image);
+		this.tgvState = new TGVMinimizer2DSolverState<T>(ops, image);
+		this.type = image.randomAccess().get().createVariable();
+	}
+	
+	public RandomAccessibleInterval<T> getResultImage(final int i) {
+		if (i != 0) {
+			throw new ArrayIndexOutOfBoundsException("Only one result available.");
+		}
+		return this.result;
+	}
+
+	public DualVariables<T> getRegularizerDV() {
+		return this.regularizerDV;
+	}
+
+	public DualVariables<T> getCostFunctionDV() {
+		return this.costFunctionDV;
+	}
+
+	public T getType() {
+		return this.type;
+	}
+
+	public RandomAccessibleInterval<T> getIntermediateResult(final int i) {
+		if (i != 0) {
+			throw new ArrayIndexOutOfBoundsException("Only one intermediate result available.");
+		}
+		return this.tmp;
+	}
+
+	public SolverState<T> getSubSolverState(int i) {
+		if (i > 0) {
+			throw new ArrayIndexOutOfBoundsException("This solver only depends on one other sovler.");
+		}
+		return tgvState;
+	}
+
+	public int numResultImages() {
+		return 1;
+	}
+
+	public int numIntermediateResults() {
+		return 1;
+	}
+}

--- a/src/main/java/net/imagej/ops/fopd/solver/TVHuberL1DenoisingSolverState.java
+++ b/src/main/java/net/imagej/ops/fopd/solver/TVHuberL1DenoisingSolverState.java
@@ -8,8 +8,9 @@ import net.imglib2.type.numeric.RealType;
 /**
  * Specific implementation of {@link SolverState} for L1-TVHuber-Denoising.
  * 
- * Energy: E(u) = lambda * TV-Huber(u)_alpha + |u - f|_1, where u is the denoised solution,
- * lambda is the smoothness weight and f is the observed image.
+ * Energy: E(u) = lambda * TV-Huber(u)_alpha + |u - f|_1, where u is the
+ * denoised solution, lambda is the smoothness weight and f is the observed
+ * image.
  * 
  * @author Tim-Oliver Buchholz, University of Konstanz.
  *
@@ -17,13 +18,9 @@ import net.imglib2.type.numeric.RealType;
  */
 public class TVHuberL1DenoisingSolverState<T extends RealType<T>> implements SolverState<T> {
 
-	private int numIterations;
-
-	private double lambda;
-	
-	private double alpha;
-
 	private RandomAccessibleInterval<T> image;
+
+	private RandomAccessibleInterval<T> result;
 
 	private DualVariables<T> regularizerDV;
 
@@ -32,11 +29,7 @@ public class TVHuberL1DenoisingSolverState<T extends RealType<T>> implements Sol
 	private RandomAccessibleInterval<T> tmp;
 
 	@SuppressWarnings("unchecked")
-	public TVHuberL1DenoisingSolverState(final OpService ops, final int numIterations, final double lambda, final double alpha,
-			final RandomAccessibleInterval<T> image) {
-		this.numIterations = numIterations;
-		this.lambda = lambda;
-		this.alpha = alpha;
+	public TVHuberL1DenoisingSolverState(final OpService ops, final RandomAccessibleInterval<T> image) {
 		this.image = image;
 
 		this.regularizerDV = new DualVariables<T>((RandomAccessibleInterval<T>) ops.create().img(image),
@@ -44,22 +37,14 @@ public class TVHuberL1DenoisingSolverState<T extends RealType<T>> implements Sol
 		this.costFunctionDV = new DualVariables<T>((RandomAccessibleInterval<T>) ops.create().img(image));
 
 		this.tmp = (RandomAccessibleInterval<T>) ops.create().img(image);
+		this.result = (RandomAccessibleInterval<T>) ops.create().img(image);
 	}
 
-	public int getNumIterations() {
-		return this.numIterations;
-	}
-
-	public double getLambda() {
-		return this.lambda;
-	}
-	
-	public double getAlpha() {
-		return this.alpha;
-	}
-
-	public RandomAccessibleInterval<T> getImage() {
-		return this.image;
+	public RandomAccessibleInterval<T> getResultImage(final int i) {
+		if (i != 0) {
+			throw new ArrayIndexOutOfBoundsException("Only one result available.");
+		}
+		return this.result;
 	}
 
 	public DualVariables<T> getRegularizerDV() {
@@ -74,7 +59,22 @@ public class TVHuberL1DenoisingSolverState<T extends RealType<T>> implements Sol
 		return image.randomAccess().get().createVariable();
 	}
 
-	public RandomAccessibleInterval<T> getIntermediateResult() {
+	public RandomAccessibleInterval<T> getIntermediateResult(final int i) {
+		if (i != 0) {
+			throw new ArrayIndexOutOfBoundsException("Only one intermediate result available.");
+		}
 		return this.tmp;
+	}
+
+	public SolverState<T> getSubSolverState(int i) {
+		throw new NullPointerException("This denoising solver does not depend on another solver.");
+	}
+
+	public int numResultImages() {
+		return 1;
+	}
+
+	public int numIntermediateResults() {
+		return 1;
 	}
 }

--- a/src/main/java/net/imagej/ops/fopd/solver/TVL1Deconvolution2DSolverState.java
+++ b/src/main/java/net/imagej/ops/fopd/solver/TVL1Deconvolution2DSolverState.java
@@ -18,49 +18,34 @@ import net.imglib2.type.numeric.RealType;
  */
 public class TVL1Deconvolution2DSolverState<T extends RealType<T>> implements SolverState<T> {
 
-	private int numIterations;
-
-	private double lambda;
-
-	private RandomAccessibleInterval<T> image;
-	
-	private RandomAccessibleInterval<T> kernel;
-
 	private DualVariables<T> regularizerDV;
 
 	private DualVariables<T> costFunctionDV;
 
 	private RandomAccessibleInterval<T> tmp;
 
+	private RandomAccessibleInterval<T> result;
+
+	private T type;
+
 	@SuppressWarnings("unchecked")
-	public TVL1Deconvolution2DSolverState(final OpService ops, final int numIterations, final double lambda,
-			final RandomAccessibleInterval<T> image, final RandomAccessibleInterval<T> kernel) {
-		this.numIterations = numIterations;
-		this.lambda = lambda;
-		this.image = image;
-		this.kernel = kernel;
+	public TVL1Deconvolution2DSolverState(final OpService ops,
+			final RandomAccessibleInterval<T> image) {
 
 		this.regularizerDV = new DualVariables<T>((RandomAccessibleInterval<T>) ops.create().img(image),
 				(RandomAccessibleInterval<T>) ops.create().img(image));
 		this.costFunctionDV = new DualVariables<T>((RandomAccessibleInterval<T>) ops.create().img(image));
 
 		this.tmp = (RandomAccessibleInterval<T>) ops.create().img(image);
-	}
-
-	public int getNumIterations() {
-		return this.numIterations;
-	}
-
-	public double getLambda() {
-		return this.lambda;
-	}
-
-	public RandomAccessibleInterval<T> getImage() {
-		return this.image;
+		this.result = (RandomAccessibleInterval<T>) ops.create().img(image);
+		this.type = image.randomAccess().get().createVariable();
 	}
 	
-	public RandomAccessibleInterval<T> getKernel() {
-		return this.kernel;
+	public RandomAccessibleInterval<T> getResultImage(final int i) {
+		if (i != 0) {
+			throw new ArrayIndexOutOfBoundsException("Only one result available.");
+		}
+		return this.result;
 	}
 
 	public DualVariables<T> getRegularizerDV() {
@@ -72,10 +57,25 @@ public class TVL1Deconvolution2DSolverState<T extends RealType<T>> implements So
 	}
 
 	public T getType() {
-		return image.randomAccess().get().createVariable();
+		return this.type;
 	}
 
-	public RandomAccessibleInterval<T> getIntermediateResult() {
+	public RandomAccessibleInterval<T> getIntermediateResult(final int i) {
+		if (i != 0) {
+			throw new ArrayIndexOutOfBoundsException("Only one intermediate result available.");
+		}
 		return this.tmp;
+	}
+
+	public SolverState<T> getSubSolverState(int i) {
+		throw new NullPointerException("This deconvolution solver does not depend on another solver.");
+	}
+
+	public int numResultImages() {
+		return 1;
+	}
+
+	public int numIntermediateResults() {
+		return 1;
 	}
 }

--- a/src/main/java/net/imagej/ops/fopd/solver/TVL1DenoisingSolverState.java
+++ b/src/main/java/net/imagej/ops/fopd/solver/TVL1DenoisingSolverState.java
@@ -17,42 +17,34 @@ import net.imglib2.type.numeric.RealType;
  */
 public class TVL1DenoisingSolverState<T extends RealType<T>> implements SolverState<T> {
 
-	private int numIterations;
-
-	private double lambda;
-
-	private RandomAccessibleInterval<T> image;
-
 	private DualVariables<T> regularizerDV;
 
 	private DualVariables<T> costFunctionDV;
 
 	private RandomAccessibleInterval<T> tmp;
 
+	private RandomAccessibleInterval<T> result;
+
+	private T type;
+
 	@SuppressWarnings("unchecked")
-	public TVL1DenoisingSolverState(final OpService ops, final int numIterations, final double lambda,
+	public TVL1DenoisingSolverState(final OpService ops, 
 			final RandomAccessibleInterval<T> image) {
-		this.numIterations = numIterations;
-		this.lambda = lambda;
-		this.image = image;
 
 		this.regularizerDV = new DualVariables<T>((RandomAccessibleInterval<T>) ops.create().img(image),
 				(RandomAccessibleInterval<T>) ops.create().img(image));
 		this.costFunctionDV = new DualVariables<T>((RandomAccessibleInterval<T>) ops.create().img(image));
 
 		this.tmp = (RandomAccessibleInterval<T>) ops.create().img(image);
+		this.result = (RandomAccessibleInterval<T>) ops.create().img(image);
+		this.type = image.randomAccess().get().createVariable();
 	}
-
-	public int getNumIterations() {
-		return this.numIterations;
-	}
-
-	public double getLambda() {
-		return this.lambda;
-	}
-
-	public RandomAccessibleInterval<T> getImage() {
-		return this.image;
+	
+	public RandomAccessibleInterval<T> getResultImage(final int i) {
+		if (i != 0) {
+			throw new ArrayIndexOutOfBoundsException("Only one result available.");
+		}
+		return this.result;
 	}
 
 	public DualVariables<T> getRegularizerDV() {
@@ -64,10 +56,25 @@ public class TVL1DenoisingSolverState<T extends RealType<T>> implements SolverSt
 	}
 
 	public T getType() {
-		return image.randomAccess().get().createVariable();
+		return this.type;
 	}
 
-	public RandomAccessibleInterval<T> getIntermediateResult() {
+	public RandomAccessibleInterval<T> getIntermediateResult(final int i) {
+		if (i != 0) {
+			throw new ArrayIndexOutOfBoundsException("Only one intermediate result available.");
+		}
 		return this.tmp;
+	}
+
+	public SolverState<T> getSubSolverState(int i) {
+		throw new NullPointerException("This denoising solver does not depend on another solver.");
+	}
+
+	public int numResultImages() {
+		return 1;
+	}
+
+	public int numIntermediateResults() {
+		return 1;
 	}
 }

--- a/src/test/java/net/imagej/ops/fopd/SolverTest.java
+++ b/src/test/java/net/imagej/ops/fopd/SolverTest.java
@@ -9,6 +9,7 @@ import net.imglib2.type.numeric.real.DoubleType;
 import org.junit.Test;
 
 /**
+ * Tests of the implemented solvers.
  * 
  * @author Tim-Oliver Buchholz, University of Konstanz
  *
@@ -21,10 +22,13 @@ public class SolverTest extends AbstractOpTest {
 	final static double[] expectedTVHuberL1Denoising = new double[] { 1.0, 0.7834267473541114, 1.0, 1.0, 1.0, 1.0, 1.0,
 			1.0, 1.0 };
 
-	final static double[] exptectedTVL1Deconvolution = new double[] { 0.852645952127457, 0.9599103235969544, 1.0,
+	final static double[] expectedTGVL1Denoising = new double[] { 1.0, 0.7480864124025571, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+			1.0 };
+
+	final static double[] expectedTVL1Deconvolution = new double[] { 0.852645952127457, 0.9599103235969544, 1.0,
 			0.9014054497424371, 1.0, 1.0, 0.8526459284847978, 0.9599102998930213, 1.0 };
 
-	final static double[] exptectedTVHuberL1Deconvolution = new double[] { 0.8449143152960898, 0.9578770115357464, 1.0,
+	final static double[] expectedTVHuberL1Deconvolution = new double[] { 0.8449143152960898, 0.9578770115357464, 1.0,
 			0.8949538345908679, 1.0, 1.0, 0.8449142943570016, 0.9578769702830028, 1.0 };
 
 	@Test
@@ -54,6 +58,19 @@ public class SolverTest extends AbstractOpTest {
 	}
 
 	@Test
+	public void TGVL1DenoisingTest() {
+
+		@SuppressWarnings("unchecked")
+		final Cursor<DoubleType> c = ((Img<DoubleType>) ops.run(TGVL1Denoising.class, img, 0.5, 1, 10)).cursor();
+		int i = 0;
+		while (c.hasNext()) {
+			c.next();
+			assertEquals("Pixel at [" + c.getDoublePosition(0) + "," + c.getDoublePosition(1) + "] differs.",
+					expectedTGVL1Denoising[i++], c.get().get(), 0);
+		}
+	}
+
+	@Test
 	public void TVL1DeconvolutionTest() {
 
 		@SuppressWarnings("unchecked")
@@ -63,7 +80,7 @@ public class SolverTest extends AbstractOpTest {
 		while (c.hasNext()) {
 			c.next();
 			assertEquals("Pixel at [" + c.getDoublePosition(0) + "," + c.getDoublePosition(1) + "] differs.",
-					exptectedTVL1Deconvolution[i++], c.get().get(), 0);
+					expectedTVL1Deconvolution[i++], c.get().get(), 0);
 		}
 	}
 
@@ -77,7 +94,7 @@ public class SolverTest extends AbstractOpTest {
 		while (c.hasNext()) {
 			c.next();
 			assertEquals("Pixel at [" + c.getDoublePosition(0) + "," + c.getDoublePosition(1) + "] differs.",
-					exptectedTVHuberL1Deconvolution[i++], c.get().get(), 0);
+					expectedTVHuberL1Deconvolution[i++], c.get().get(), 0);
 		}
 	}
 }

--- a/src/test/java/net/imagej/ops/fopd/costfunction/DeconvolveTest.java
+++ b/src/test/java/net/imagej/ops/fopd/costfunction/DeconvolveTest.java
@@ -3,41 +3,53 @@ package net.imagej.ops.fopd.costfunction;
 import static org.junit.Assert.assertEquals;
 
 import net.imagej.ops.fopd.AbstractOpTest;
-import net.imagej.ops.fopd.DualVariables;
 import net.imagej.ops.fopd.costfunction.deconvolution.L1Deconvolution2DAscent;
 import net.imagej.ops.fopd.costfunction.deconvolution.L1Deconvolution2DDescent;
+import net.imagej.ops.fopd.solver.SolverState;
+import net.imagej.ops.fopd.solver.TVL1DenoisingSolverState;
 import net.imglib2.Cursor;
-import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.img.Img;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccess;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.view.Views;
 
 import org.junit.Test;
 
+/**
+ * Deconvolution tests.
+ * 
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ */
 public class DeconvolveTest extends AbstractOpTest {
 
 	private static double[] expected = new double[] { -0.08500000089406967, -0.08999999612569809, -0.11500000208616257,
 			-0.08749999850988388, -0.0924999937415123, -0.08500000089406967, -0.08500000089406967, -0.08999999612569809,
-			-0.11500000208616257 };
+-0.11500000208616257 };
 
 	@SuppressWarnings("unchecked")
 	@Test
 	public void l1DeconvolutionTest() {
 
-		Img<DoubleType> result = ops.create().img(img);
-
 		final L1Deconvolution2DAscent<DoubleType> ascentL1Denoising = ops.op(L1Deconvolution2DAscent.class,
-				RandomAccessibleInterval.class, DualVariables.class, posNegImg, kernel);
+				SolverState.class, posNegImg, kernel);
 		final L1Deconvolution2DDescent<DoubleType> descentL1Denoising = ops.op(L1Deconvolution2DDescent.class,
-				RandomAccessibleInterval.class, DualVariables.class, Views.invertAxis(Views.invertAxis(kernel, 0), 1),
-				0.25);
+				SolverState.class, Views.invertAxis(Views.invertAxis(kernel, 0), 1), 0.25);
 
-		final DualVariables<DoubleType> q = new DualVariables<DoubleType>(ops.create().img(img));
+		final SolverState<DoubleType> state = new TVL1DenoisingSolverState<DoubleType>(ops, ops.create().img(img));
+		RandomAccess<DoubleType> ra = state.getResultImage(0).randomAccess();
+		Cursor<DoubleType> c = img.cursor();
 
-		ascentL1Denoising.compute(q, img);
-		descentL1Denoising.compute(q, result);
+		while (c.hasNext()) {
+			c.next();
+			ra.setPosition(c);
+			ra.get().set(c.get().get());
+		}
 
-		final Cursor<DoubleType> c = result.cursor();
+		ascentL1Denoising.calculate(state);
+		descentL1Denoising.calculate(state);
+
+		c = ((IterableInterval<DoubleType>) state.getIntermediateResult(0)).cursor();
 		int i = 0;
 		while (c.hasNext()) {
 			assertEquals("L1 Deconvolution differs", expected[i++], c.next().get(), 0);

--- a/src/test/java/net/imagej/ops/fopd/helper/BackwardDifferenceTest.java
+++ b/src/test/java/net/imagej/ops/fopd/helper/BackwardDifferenceTest.java
@@ -2,14 +2,14 @@ package net.imagej.ops.fopd.helper;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Test;
-
 import net.imagej.ops.fopd.AbstractOpTest;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
 import net.imglib2.outofbounds.OutOfBoundsBorderFactory;
 import net.imglib2.type.numeric.real.DoubleType;
+
+import org.junit.Test;
 
 /**
  * Test for {@link DefaultBackwardDifference}.

--- a/src/test/java/net/imagej/ops/fopd/helper/DivergenceTest2D.java
+++ b/src/test/java/net/imagej/ops/fopd/helper/DivergenceTest2D.java
@@ -2,16 +2,15 @@ package net.imagej.ops.fopd.helper;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Test;
-
 import net.imagej.ops.fopd.AbstractOpTest;
-import net.imagej.ops.fopd.DualVariables;
 import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
 import net.imglib2.outofbounds.OutOfBoundsBorderFactory;
 import net.imglib2.type.numeric.real.DoubleType;
+
+import org.junit.Test;
 
 /**
  * Test for {@link DefaultBackwardDifference}.
@@ -34,10 +33,8 @@ public class DivergenceTest2D extends AbstractOpTest {
 				new OutOfBoundsBorderFactory<DoubleType, RandomAccessibleInterval<DoubleType>>()));
 
 		@SuppressWarnings("unchecked")
-		DualVariables<DoubleType> d = new DualVariables<DoubleType>(gradientX, gradientY);
-
-		@SuppressWarnings("unchecked")
-		final Cursor<DoubleType> c = ((IterableInterval<DoubleType>) ops.run(DefaultDivergence2D.class, d)).cursor();
+		final Cursor<DoubleType> c = ((IterableInterval<DoubleType>) ops.run(DefaultDivergence2D.class,
+				RandomAccessibleInterval.class, new RandomAccessibleInterval[] { gradientX, gradientY })).cursor();
 		int i = 0;
 		while (c.hasNext()) {
 			assertEquals("Divergence differs", expected[i++], c.next().get(), 0);

--- a/src/test/java/net/imagej/ops/fopd/helper/ForwardDifferenceTest.java
+++ b/src/test/java/net/imagej/ops/fopd/helper/ForwardDifferenceTest.java
@@ -2,14 +2,14 @@ package net.imagej.ops.fopd.helper;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Test;
-
 import net.imagej.ops.fopd.AbstractOpTest;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
 import net.imglib2.outofbounds.OutOfBoundsBorderFactory;
 import net.imglib2.type.numeric.real.DoubleType;
+
+import org.junit.Test;
 
 /**
  * Test for {@link DefaultForwardDifference}.

--- a/src/test/java/net/imagej/ops/fopd/helper/L2NormTest.java
+++ b/src/test/java/net/imagej/ops/fopd/helper/L2NormTest.java
@@ -2,18 +2,19 @@ package net.imagej.ops.fopd.helper;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Test;
-
 import net.imagej.ops.fopd.AbstractOpTest;
-import net.imagej.ops.fopd.DualVariables;
 import net.imagej.ops.special.computer.Computers;
 import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imglib2.Cursor;
+import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.real.DoubleType;
 
+import org.junit.Test;
+
 /**
+ * L2-Norm tests.
  * 
  * @author Tim-Oliver Buchholz, University of Konstanz
  *
@@ -28,15 +29,14 @@ public class L2NormTest extends AbstractOpTest {
 			0.8660254037844386, 1.7320508075688772, 0.8660254037844386, 0.8660254037844386, 0.8660254037844386,
 			0.8660254037844386 };
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings({ "rawtypes" })
 	@Test
 	public void L2Norm1DTest() {
-		final UnaryComputerOp<DualVariables, RandomAccessibleInterval> normComputer = Computers.unary(ops,
-				DefaultL2Norm.class, RandomAccessibleInterval.class, DualVariables.class);
+		final UnaryComputerOp<RandomAccessibleInterval[], RandomAccessibleInterval> normComputer = Computers.unary(ops,
+				DefaultL2Norm.class, RandomAccessibleInterval.class, RandomAccessibleInterval[].class);
 
 		final Img<DoubleType> result = ops.create().img(posNegImg);
-		final DualVariables<DoubleType> input = new DualVariables<DoubleType>(posNegImg);
-		normComputer.compute(input, result);
+		normComputer.compute(new RandomAccessibleInterval[] { posNegImg }, result);
 
 		final Cursor<DoubleType> c = result.cursor();
 		int i = 0;
@@ -46,17 +46,15 @@ public class L2NormTest extends AbstractOpTest {
 
 	}
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings({ "rawtypes" })
 	@Test
 	public void L2Norm2DTest() {
-		final UnaryComputerOp<DualVariables, RandomAccessibleInterval> normComputer = Computers.unary(ops,
-				DefaultL2Norm.class, RandomAccessibleInterval.class, DualVariables.class);
+		final UnaryComputerOp<RandomAccessibleInterval[], RandomAccessibleInterval> normComputer = Computers.unary(ops,
+				DefaultL2Norm.class, RandomAccessibleInterval.class, RandomAccessibleInterval[].class);
 
 		final Img<DoubleType> result = ops.create().img(posNegImg);
 
-		DualVariables<DoubleType> input = new DualVariables<DoubleType>(posNegImg, posNegImg);
-
-		normComputer.compute(input, result);
+		normComputer.compute(new RandomAccessibleInterval[] { posNegImg, posNegImg }, result);
 
 		final Cursor<DoubleType> c = result.cursor();
 		int i = 0;
@@ -66,16 +64,15 @@ public class L2NormTest extends AbstractOpTest {
 
 	}
 
+	@SuppressWarnings("rawtypes")
 	@Test
 	public void L2Norm3DTest() {
-		final UnaryComputerOp<DualVariables, RandomAccessibleInterval> normComputer = Computers.unary(ops,
-				DefaultL2Norm.class, RandomAccessibleInterval.class, DualVariables.class);
+		final UnaryComputerOp<RandomAccessibleInterval[], RandomAccessibleInterval> normComputer = Computers.unary(ops,
+				DefaultL2Norm.class, RandomAccessibleInterval.class, RandomAccessibleInterval[].class);
 
 		final Img<DoubleType> result = ops.create().img(posNegImg);
 
-		DualVariables<DoubleType> input = new DualVariables<DoubleType>(posNegImg, posNegImg, posNegImg);
-
-		normComputer.compute(input, result);
+		normComputer.compute(new RandomAccessibleInterval[] { posNegImg, posNegImg, posNegImg }, result);
 
 		final Cursor<DoubleType> c = result.cursor();
 		int i = 0;
@@ -84,26 +81,22 @@ public class L2NormTest extends AbstractOpTest {
 		}
 	}
 
+	@SuppressWarnings("rawtypes")
 	@Test
 	public void L2Norm4DTest() {
-		// Currently not working because of matcher bug!
-		// final UnaryComputerOp<DualVariables, RandomAccessibleInterval>
-		// normComputer = Computers.unary(ops, DefaultL2Norm.class,
-		// RandomAccessibleInterval.class, DualVariables.class);
-		//
-		// final Img<DoubleType> result = ops.create().img(posNegImg);
-		// DualVariables<DoubleType> input = new
-		// DualVariables<DoubleType>(posNegImg, posNegImg, posNegImg,
-		// posNegImg);
-		//
-		// normComputer.compute(input, result);
-		//
-		// final RandomAccess<DoubleType> ra = result.randomAccess();
-		// for (int y = 0; y < result.dimension(1); y++) {
-		// for (int x = 0; x < result.dimension(0); x++) {
-		// ra.setPosition(new int[] { x, y });
-		// assertEquals("L2Norm 2D", 1, ra.get().get(), 0);
-		// }
-		// }
+		final UnaryComputerOp<RandomAccessibleInterval[], RandomAccessibleInterval> normComputer = Computers.unary(ops,
+				DefaultL2Norm.class, RandomAccessibleInterval.class, RandomAccessibleInterval[].class);
+
+		final Img<DoubleType> result = ops.create().img(posNegImg);
+
+		normComputer.compute(new RandomAccessibleInterval[] { posNegImg, posNegImg, posNegImg, posNegImg }, result);
+
+		final RandomAccess<DoubleType> ra = result.randomAccess();
+		for (int y = 0; y < result.dimension(1); y++) {
+			for (int x = 0; x < result.dimension(0); x++) {
+				ra.setPosition(new int[] { x, y });
+				assertEquals("L2Norm 2D", 1, ra.get().get(), 1);
+			}
+		}
 	}
 }

--- a/src/test/java/net/imagej/ops/fopd/helper/ProjectL1Test.java
+++ b/src/test/java/net/imagej/ops/fopd/helper/ProjectL1Test.java
@@ -2,8 +2,6 @@ package net.imagej.ops.fopd.helper;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Test;
-
 import net.imagej.ops.fopd.AbstractOpTest;
 import net.imagej.ops.fopd.DualVariables;
 import net.imagej.ops.special.computer.Computers;
@@ -16,7 +14,10 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.real.DoubleType;
 
+import org.junit.Test;
+
 /**
+ * Tests of L1-back-projection.
  * 
  * @author Tim-Oliver Buchholz, University of Konstanz
  *
@@ -35,13 +36,13 @@ public class ProjectL1Test extends AbstractOpTest {
 	public void projectL1Test01() {
 		final Img<DoubleType> result = ops.copy().img(posNegImg);
 
-		final UnaryComputerOp<DualVariables, RandomAccessibleInterval> normComputer = Computers.unary(ops,
-				DefaultL2Norm.class, RandomAccessibleInterval.class, DualVariables.class);
+		final UnaryComputerOp<RandomAccessibleInterval[], RandomAccessibleInterval> normComputer = Computers.unary(ops,
+				DefaultL2Norm.class, RandomAccessibleInterval.class, RandomAccessibleInterval[].class);
 
 		final Img<DoubleType> norm = ops.create().img(posNegImg);
 		DualVariables<DoubleType> input = new DualVariables<DoubleType>(ops.copy().img(posNegImg),
 				ops.copy().img(posNegImg));
-		normComputer.compute(input, norm);
+		normComputer.compute(input.getAllDualVariables(), norm);
 
 		final BinaryInplace1Op<? super DoubleType, DoubleType, DoubleType> projector = Inplaces.binary1(ops,
 				DefaultL1Projector.class, DoubleType.class, DoubleType.class, 0.1);
@@ -60,13 +61,13 @@ public class ProjectL1Test extends AbstractOpTest {
 	public void projectL1Test05() {
 		final Img<DoubleType> result = ops.copy().img(posNegImg);
 
-		final UnaryComputerOp<DualVariables, RandomAccessibleInterval> normComputer = Computers.unary(ops,
-				DefaultL2Norm.class, RandomAccessibleInterval.class, DualVariables.class);
+		final UnaryComputerOp<RandomAccessibleInterval[], RandomAccessibleInterval> normComputer = Computers.unary(ops,
+				DefaultL2Norm.class, RandomAccessibleInterval.class, RandomAccessibleInterval[].class);
 
 		final Img<DoubleType> norm = ops.create().img(posNegImg);
 		DualVariables<DoubleType> input = new DualVariables<DoubleType>(ops.copy().img(posNegImg),
 				ops.copy().img(posNegImg));
-		normComputer.compute(input, norm);
+		normComputer.compute(input.getAllDualVariables(), norm);
 
 		final BinaryInplace1Op<? super DoubleType, DoubleType, DoubleType> projector = Inplaces.binary1(ops,
 				DefaultL1Projector.class, DoubleType.class, DoubleType.class, 0.5);

--- a/src/test/java/net/imagej/ops/fopd/regularizer/TVHuberTest.java
+++ b/src/test/java/net/imagej/ops/fopd/regularizer/TVHuberTest.java
@@ -3,15 +3,19 @@ package net.imagej.ops.fopd.regularizer;
 import static org.junit.Assert.assertEquals;
 
 import net.imagej.ops.fopd.AbstractOpTest;
-import net.imagej.ops.fopd.DualVariables;
+import net.imagej.ops.fopd.regularizer.tvhuber.TVHuber2DAscent;
+import net.imagej.ops.fopd.regularizer.tvhuber.TVHuber2DDescent;
+import net.imagej.ops.fopd.solver.SolverState;
+import net.imagej.ops.fopd.solver.TVL1DenoisingSolverState;
 import net.imglib2.Cursor;
-import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.img.Img;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccess;
 import net.imglib2.type.numeric.real.DoubleType;
 
 import org.junit.Test;
 
 /**
+ * Total Variation with Huber-Norm test.
  * 
  * @author Tim-Oliver Buchholz, University of Konstanz
  *
@@ -25,19 +29,23 @@ public class TVHuberTest extends AbstractOpTest {
 	@Test
 	public void tvHuberTest() {
 
-		Img<DoubleType> result = ops.create().img(img);
+		final TVHuber2DAscent<DoubleType> ascentTVHuber = ops.op(TVHuber2DAscent.class, SolverState.class, 0.5, 0.1);
+		final TVHuber2DDescent<DoubleType> descentTVHuber = ops.op(TVHuber2DDescent.class, SolverState.class, 0.25);
 
-		final TVHuber2DAscent<DoubleType> ascentTVHuber = ops.op(TVHuber2DAscent.class, RandomAccessibleInterval.class,
-				DualVariables.class, 0.5, 0.1);
-		final TVHuber2DDescent<DoubleType> descentTVHuber = ops.op(TVHuber2DDescent.class,
-				RandomAccessibleInterval.class, DualVariables.class, 0.25);
+		final SolverState<DoubleType> state = new TVL1DenoisingSolverState<DoubleType>(ops, ops.create().img(img));
+		RandomAccess<DoubleType> ra = state.getResultImage(0).randomAccess();
+		Cursor<DoubleType> c = img.cursor();
 
-		final DualVariables<DoubleType> p = new DualVariables<DoubleType>(ops.create().img(img), ops.create().img(img));
+		while (c.hasNext()) {
+			c.next();
+			ra.setPosition(c);
+			ra.get().set(c.get().get());
+		}
 
-		ascentTVHuber.compute(p, img);
-		descentTVHuber.compute(p, result);
+		ascentTVHuber.calculate(state);
+		descentTVHuber.calculate(state);
 
-		final Cursor<DoubleType> c = result.cursor();
+		c = ((IterableInterval<DoubleType>) state.getIntermediateResult(0)).cursor();
 		int i = 0;
 		while (c.hasNext()) {
 			assertEquals("TV-Huber differs", expected[i++], c.next().get(), 0);


### PR DESCRIPTION
This PR adds the Total Generalized Variation (TGV) regularizer. (https://github.com/tibuch/FOPD-Solver/issues/5)
Also `HybridCFOp` is replaced by `FunctionOp` since the intermediate results of the `DualVariables` and the images are stored in the `SolverState`. `SolverState` is improved and always returned. (https://github.com/tibuch/FOPD-Solver/issues/16)